### PR TITLE
Attempt to fix failing OpenapigenerationTest

### DIFF
--- a/cobigen-eclipse/cobigen-eclipse-test/.classpath
+++ b/cobigen-eclipse/cobigen-eclipse-test/.classpath
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="lib/core-test-5.0.0.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="src" path="src/main/java/"/>
 	<classpathentry exported="true" kind="lib" path="lib/jcl-over-slf4j-1.7.21.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/log4j-over-slf4j-1.7.21.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/slf4j-api-1.7.21.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/assertj-core-3.8.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/core-test-5.0.0.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/pom.xml
+++ b/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.devonfw.cobigen</groupId>
   <artifactId>templates-oasp</artifactId>
@@ -19,7 +21,7 @@
       </plugin>
     </plugins>
   </build>
-  
+
   <dependencies>
     <dependency>
       <groupId>com.devonfw.cobigen</groupId>

--- a/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/src/main/java/constants/Field.java
+++ b/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/src/main/java/constants/Field.java
@@ -1,4 +1,4 @@
-package constants.pojo;
+package constants;
 
 /**
  * Contains the used keys for the pojo field Map&lt;String, Object>

--- a/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/src/main/java/constants/pojo/Field.java
+++ b/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/src/main/java/constants/pojo/Field.java
@@ -1,4 +1,4 @@
-package constants;
+package constants.pojo;
 
 /**
  * Contains the used keys for the pojo field Map&lt;String, Object>
@@ -31,7 +31,6 @@ public enum Field {
     /**
      * key value
      */
-    @SuppressWarnings("unused")
     private String value;
 
     /**

--- a/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/src/main/java/utils/OaspUtil.java
+++ b/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/src/main/java/utils/OaspUtil.java
@@ -3,7 +3,7 @@ package utils;
 import java.util.Collection;
 import java.util.Map;
 
-import constants.Field;
+//import constants.pojo.Field;
 
 /**
  * A class for shared oasp4j specific functions in the templates
@@ -241,14 +241,14 @@ public class OaspUtil {
     public String resolveIdVariableNameOrSetterGetterSuffix(Map<String, Object> field, boolean byObjectReference,
         boolean capitalize, String component) {
 
-        String fieldName = (String) field.get(Field.NAME.toString());
+        String fieldName = "";// (String) field.get(Field.NAME.toString());
         if (capitalize) {
             fieldName = fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
         }
         String suffix = "";
 
-        String fieldType = (String) field.get(Field.TYPE.toString());
-        String fieldCType = (String) field.get(Field.CANONICAL_TYPE.toString());
+        String fieldType = "";// (String) field.get(Field.TYPE.toString());
+        String fieldCType = "";// (String) field.get(Field.CANONICAL_TYPE.toString());
         if (fieldType.contains("Entity")) {
             if (fieldCType.startsWith("java.util.List") || fieldCType.startsWith("java.util.Set")) {
                 suffix = "Ids";
@@ -293,13 +293,13 @@ public class OaspUtil {
         boolean byObjectReference, boolean capitalize, String component)
         throws NoSuchFieldException, SecurityException {
 
-        String resultName = (String) fieldMap.get(Field.NAME.toString());
+        String resultName = "";// (String) fieldMap.get(Field.NAME.toString());
         if (capitalize) {
             resultName = resultName.substring(0, 1).toUpperCase() + resultName.substring(1);
         }
         String suffix = "";
-        String fieldType = (String) fieldMap.get(Field.TYPE.toString());
-        String fieldName = (String) fieldMap.get(Field.NAME.toString());
+        String fieldType = "";// (String) fieldMap.get(Field.TYPE.toString());
+        String fieldName = "";// (String) fieldMap.get(Field.NAME.toString());
         if (fieldType.contains("Entity")) {
             if (Collection.class.isAssignableFrom(pojoClass.getDeclaredField(fieldName).getType())) {
                 suffix = "Ids";
@@ -332,7 +332,7 @@ public class OaspUtil {
      */
     public String getSimpleEntityTypeAsLongReference(Map<String, Object> field) {
 
-        String fieldType = (String) field.get(Field.TYPE.toString());
+        String fieldType = "";// (String) field.get(Field.TYPE.toString());
         if (fieldType.contains("Entity")) {
             fieldType = fieldType.replaceAll("[^<>]+Entity", "Long");
         }

--- a/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/src/main/java/utils/OaspUtil.java
+++ b/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/src/main/java/utils/OaspUtil.java
@@ -3,7 +3,7 @@ package utils;
 import java.util.Collection;
 import java.util.Map;
 
-import constants.pojo.Field;
+import constants.Field;
 
 /**
  * A class for shared oasp4j specific functions in the templates

--- a/cobigen-eclipse/cobigen-eclipse/.classpath
+++ b/cobigen-eclipse/cobigen-eclipse/.classpath
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="lib/core-5.0.0.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/core-api-5.0.0.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/javaplugin-model-2.0.0.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/"/>
@@ -22,5 +19,8 @@
 	<classpathentry exported="true" kind="lib" path="lib/logback-core-1.1.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/mmm-util-core-7.4.0.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/slf4j-api-1.7.21.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/core-5.0.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/core-api-5.0.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/javaplugin-model-2.0.0.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
OpenAPITest.testBasicOpenAPIGeneration throws a classNotFoundException as it cannot find constants.pojo.Field.
This does not happen when executing the test locally, so this pull request will contain attempts to fix this bug.

Attempt 1: Simply rename the package to what it is in the oasp4j-templates on the master branch, test works the same as before the change locally - Error still exists, but not reported in the failing test
