### PR TITLE
Implementing modification counter for Angular client

### DIFF
--- a/cobigen-templates/templates-oasp4j/crud_angular_client_app/templates/src/app/${variables.etoName#lower_case}/services/${variables.etoName#lower_case}.service.ts.ftl
+++ b/cobigen-templates/templates-oasp4j/crud_angular_client_app/templates/src/app/${variables.etoName#lower_case}/services/${variables.etoName#lower_case}.service.ts.ftl
@@ -33,6 +33,7 @@ export class ${variables.etoName?cap_first}Service {
   save${variables.etoName?cap_first}(data: any): Observable<Object> {
     const obj: any = {
       id: data.id,
+      modificationCounter: data.modificationCounter,
     <#list pojo.fields as field>
       ${field.name}: data.${field.name},
     </#list>


### PR DESCRIPTION
Implements

* On the client side of Angular, the `modificationCounter` is now incremented, so that the user is able to modify entities from the database multiple times.


@devonfw/cobigen
