### PR TITLE
Fix bug aplying data of one parameter to every other one

### DIFF
--- a/cobigen/cobigen-openapiplugin-parent/cobigen-openapiplugin/src/main/java/com/devonfw/cobigen/openapiplugin/inputreader/OpenAPIInputReader.java
+++ b/cobigen/cobigen-openapiplugin-parent/cobigen-openapiplugin/src/main/java/com/devonfw/cobigen/openapiplugin/inputreader/OpenAPIInputReader.java
@@ -378,9 +378,9 @@ public class OpenAPIInputReader implements InputReader {
     private List<ParameterDef> extractParameters(Collection<? extends Parameter> parameters, Collection<String> tags,
         RequestBody requestBody) {
         List<ParameterDef> parametersList = new LinkedList<>();
-        ParameterDef parameter = new ParameterDef();
+        ParameterDef parameter;
         for (Parameter param : parameters) {
-
+            parameter = new ParameterDef();
             switch (param.getIn()) {
             case "path":
                 parameter.setInPath(true);


### PR DESCRIPTION
Adresses/Fixes #675.

Fixed a bug where, when multiple parameters were defined, only the data of the lastly defined one was saved to every parameter.
Fixed by changing the point of initilization of the ParameterDef in the input reader
