### PR TITLE
Fix YAML syntax for Travis CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install: true
 addons:
   apt:
     packages:
-      -metaCity
+      - metaCity
 
 jobs:
   include:


### PR DESCRIPTION
Adresses/Fixes broken Travis builds, as in: https://travis-ci.org/devonfw/tools-cobigen/jobs/394900583

It seems that the missing space after the `-` was causing that Travis CI couldn't detect the name of the package correctly, and this made the apt-get install command fail.

This should hopefully fix the issue!

@devonfw/cobigen
