### PR TITLE
Small issues fixed on OpenAPI templates

### DIFF
--- a/cobigen-templates/templates-oasp4j/crud_openapi_java_server_app/functions.ftl
+++ b/cobigen-templates/templates-oasp4j/crud_openapi_java_server_app/functions.ftl
@@ -9,7 +9,13 @@
     </#list>
   </#list>
   <#if result?size gte 2>
-    <#return "Object">
+    <#list operation.responses as response>
+      <#if response.code=="200">
+        <#return response.type>
+      <#else>
+        <#return "void">
+      </#if>
+    </#list>
   <#else>
     <#if result?size lt 1>
       <#return "void">
@@ -28,11 +34,12 @@
   <#assign amountOfTypes=0>
   <#list operation.responses as response>
     <#list response.mediaTypes as mt>
-      <#if !(result?contains(mt))>
+      <#assign springType = OaspUtil.getSpringMediaType(mt)>
+      <#if !(result?contains(springType))>
         <#if !(result==" ")>
           <#assign result=result+",">
         </#if>
-        <#assign result=result?trim+"MediaType."+OaspUtil.getSpringMediaType(mt)>
+        <#assign result=result?trim+"MediaType."+springType>
       </#if>
     </#list>
     </#list>

--- a/cobigen-templates/templates-oasp4j/crud_openapi_java_server_app/templates/java/${variables.rootPackage}/${variables.component#lower_case}/logic/api/${variables.component#cap_first}.java.ftl
+++ b/cobigen-templates/templates-oasp4j/crud_openapi_java_server_app/templates/java/${variables.rootPackage}/${variables.component#lower_case}/logic/api/${variables.component#cap_first}.java.ftl
@@ -69,9 +69,9 @@ public interface ${variables.component?cap_first} {
   			</#if>
   			<#list operation.parameters as parameter>
   					<#if parameter.isSearchCriteria>
-  			${OpenApiUtil.toJavaType(parameter, false)}SearchCriteriaTo criteria<#if parameter?has_next>, </#if>
+  			${OpenApiUtil.toJavaType(parameter, false)?replace("Entity","")}SearchCriteriaTo criteria<#if parameter?has_next>, </#if>
   					<#elseif parameter.isEntity>
-  		    ${OpenApiUtil.toJavaType(parameter, false)}Eto ${parameter.name?replace("Entity","")}<#if parameter?has_next>, </#if>
+  		    ${OpenApiUtil.toJavaType(parameter, false)?replace("Entity","Eto")} ${parameter.name?replace("Entity","")}<#if parameter?has_next>, </#if>
   		    	<#else>
   		    ${OpenApiUtil.toJavaType(parameter, true)} ${parameter.name}<#if parameter?has_next>, </#if>
   		    	</#if>

--- a/cobigen-templates/templates-oasp4j/crud_openapi_java_server_app/templates/java/${variables.rootPackage}/${variables.component#lower_case}/logic/api/to/${variables.entityName}Eto.java.ftl
+++ b/cobigen-templates/templates-oasp4j/crud_openapi_java_server_app/templates/java/${variables.rootPackage}/${variables.component#lower_case}/logic/api/to/${variables.entityName}Eto.java.ftl
@@ -65,7 +65,7 @@ public class ${variables.entityName}Eto extends AbstractEto implements ${variabl
       final int prime = 31;
       int result = super.hashCode();
       <#list model.properties as property>
-        <#if !property.isCollection>
+        <#if (!property.isCollection) && (property.name != "id")>
         <@definePropertyNameAndType property true/>
         <#if JavaUtil.equalsJavaPrimitive(propType)>
     result = prime * result + (${JavaUtil.castJavaPrimitives(propType,propName)}.hashCode());
@@ -92,7 +92,7 @@ public class ${variables.entityName}Eto extends AbstractEto implements ${variabl
     }
     ${variables.entityName}Eto other = (${variables.entityName}Eto) obj;
     <#list model.properties as property>
-      <#if !property.isCollection>
+      <#if (!property.isCollection) && (property.name != "id")>
       <@definePropertyNameAndType property true/>
         <#if JavaUtil.equalsJavaPrimitive(propType)>
   if(this.${propName} != other.${propName}) {

--- a/cobigen-templates/templates-oasp4j/crud_openapi_java_server_app/templates/java/${variables.rootPackage}/${variables.component#lower_case}/logic/impl/${variables.component#cap_first}Impl.java.ftl
+++ b/cobigen-templates/templates-oasp4j/crud_openapi_java_server_app/templates/java/${variables.rootPackage}/${variables.component#lower_case}/logic/impl/${variables.component#cap_first}Impl.java.ftl
@@ -112,9 +112,9 @@ public class ${variables.component?cap_first}Impl extends AbstractComponentFacad
   			</#if>
   			<#list operation.parameters as parameter>
   				<#if parameter.isSearchCriteria>
-  			${OpenApiUtil.toJavaType(parameter, false)}SearchCriteriaTo criteria<#if parameter?has_next>, </#if>
+  			${OpenApiUtil.toJavaType(parameter, false)?replace("Entity","")}SearchCriteriaTo criteria<#if parameter?has_next>, </#if>
   				<#elseif parameter.isEntity>
-  		    ${OpenApiUtil.toJavaType(parameter, false)}Eto ${parameter.name?replace("Entity","")}<#if parameter?has_next>, </#if>
+  		    ${OpenApiUtil.toJavaType(parameter, false)?replace("Entity","Eto")} ${parameter.name?replace("Entity","")}<#if parameter?has_next>, </#if>
   		    	<#else>
   		    ${OpenApiUtil.toJavaType(parameter, true)} ${parameter.name}<#if parameter?has_next>, </#if>
   		    	</#if>

--- a/cobigen-templates/templates-oasp4j/crud_openapi_java_server_app/templates/java/${variables.rootPackage}/${variables.component#lower_case}/logic/impl/${variables.component#cap_first}Impl.java.ftl
+++ b/cobigen-templates/templates-oasp4j/crud_openapi_java_server_app/templates/java/${variables.rootPackage}/${variables.component#lower_case}/logic/impl/${variables.component#cap_first}Impl.java.ftl
@@ -112,13 +112,13 @@ public class ${variables.component?cap_first}Impl extends AbstractComponentFacad
   			</#if>
   			<#list operation.parameters as parameter>
   				<#if parameter.isSearchCriteria>
-  			${OpenApiUtil.toJavaType(parameter, false)}SearchCriteriaTo criteria<#if parameter?has_next>, <#else>) {</#if>
+  			${OpenApiUtil.toJavaType(parameter, false)}SearchCriteriaTo criteria<#if parameter?has_next>, </#if>
   				<#elseif parameter.isEntity>
-  		    ${OpenApiUtil.toJavaType(parameter, false)}Eto ${parameter.name?replace("Entity","")}<#if parameter?has_next>, <#else>) {</#if>
+  		    ${OpenApiUtil.toJavaType(parameter, false)}Eto ${parameter.name?replace("Entity","")}<#if parameter?has_next>, </#if>
   		    	<#else>
-  		    ${OpenApiUtil.toJavaType(parameter, true)} ${parameter.name}<#if parameter?has_next>, <#else>) {</#if>
+  		    ${OpenApiUtil.toJavaType(parameter, true)} ${parameter.name}<#if parameter?has_next>, </#if>
   		    	</#if>
-  			</#list>
+  			</#list>) {
   		// TODO ${OpenApiUtil.printServiceOperationName(operation, path.pathURI)}
   			<#if !hasResponseOfType(responses,"Void")>
   				<#if getReturnType(operation,false) == "boolean">
@@ -131,6 +131,7 @@ public class ${variables.component?cap_first}Impl extends AbstractComponentFacad
   			</#if>		
   	}	
   		</#if>
+  		
   	</#list>
   </#list>
   

--- a/cobigen-templates/templates-oasp4j/crud_openapi_java_server_app/templates/java/${variables.rootPackage}/${variables.component#lower_case}/service/api/rest/${variables.component#cap_first}RestService.java.ftl
+++ b/cobigen-templates/templates-oasp4j/crud_openapi_java_server_app/templates/java/${variables.rootPackage}/${variables.component#lower_case}/service/api/rest/${variables.component#cap_first}RestService.java.ftl
@@ -93,7 +93,7 @@ public interface ${variables.component?cap_first}RestService {
   public ${returnType?replace("Entity", "Eto")} ${OpenApiUtil.printServiceOperationName(operation, path.pathURI)}(
     <#list operation.parameters as parameter>
     	<#if parameter.inPath>
-    	@PathParam("${parameter.name}")</#if>${OpenApiUtil.printJavaConstraints(parameter.constraints)}${OpenApiUtil.toJavaType(parameter, true)}<#if parameter.isSearchCriteria>SearchCriteriaTo<#elseif parameter.isEntity>Eto</#if> ${parameter.name}<#if parameter?has_next>, </#if></#list>);
+    	@PathParam("${parameter.name}")</#if>${OpenApiUtil.printJavaConstraints(parameter.constraints)}${OpenApiUtil.toJavaType(parameter, true)?replace("Entity","")}<#if parameter.isSearchCriteria>SearchCriteriaTo<#elseif parameter.isEntity>Eto</#if> ${parameter.name}<#if parameter?has_next>, </#if></#list>);
   		</#if>
   	</#list>
  </#list>

--- a/cobigen-templates/templates-oasp4j/crud_openapi_java_server_app/templates/java/${variables.rootPackage}/${variables.component#lower_case}/service/impl/rest/${variables.component#cap_first}RestServiceImpl.java.ftl
+++ b/cobigen-templates/templates-oasp4j/crud_openapi_java_server_app/templates/java/${variables.rootPackage}/${variables.component#lower_case}/service/impl/rest/${variables.component#cap_first}RestServiceImpl.java.ftl
@@ -54,9 +54,9 @@ public class ${variables.component?cap_first}RestServiceImpl implements ${variab
   public ${returnType?replace("Entity", "Eto")} ${OpenApiUtil.printServiceOperationName(operation, path.pathURI)}(
   			<#list operation.parameters as parameter>
   				<#if parameter.isSearchCriteria>
-  			${OpenApiUtil.toJavaType(parameter, false)}SearchCriteriaTo criteria<#if parameter?has_next>, </#if>
+  			${OpenApiUtil.toJavaType(parameter, false)?replace("Entity","")}SearchCriteriaTo criteria<#if parameter?has_next>, </#if>
   				<#elseif parameter.isEntity>
-  		  ${OpenApiUtil.toJavaType(parameter, false)}Eto ${parameter.name?replace("Entity","")}<#if parameter?has_next>, </#if>
+  		  ${OpenApiUtil.toJavaType(parameter, false)?replace("Entity","Eto")} ${parameter.name?replace("Entity","")}<#if parameter?has_next>, </#if>
   		    <#else>
   		  ${OpenApiUtil.toJavaType(parameter, true)} ${parameter.name}<#if parameter?has_next>, </#if>
   		   	</#if>


### PR DESCRIPTION
Fixes some compilation errors that we faced when generating REST services from an OpenAPI file.

Changes:

* Most of the issues were because instead of generating `SampleEto` on the method signature, it was generated `SampleEntityEto`
* Some indentation errors that generated curly brackets in wrong places.
* Some annotations fixed.

These changes are included inside the accumulative patch. I will deploy these templates to Maven when the PR is merged.

@devonfw/cobigen
