### PR TITLE
Properly load util classes in maven plugin

### DIFF
--- a/cobigen-maven/cobigen-maven-plugin/pom.xml
+++ b/cobigen-maven/cobigen-maven-plugin/pom.xml
@@ -39,12 +39,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>core</artifactId>
-      <version>5.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>core-api</artifactId>
-      <version>5.0.0</version>
+      <version>5.1.0-SNAPSHOT</version>
     </dependency>
 
     <!-- dependencies to annotations -->

--- a/cobigen-maven/cobigen-maven-plugin/src/main/java/com/devonfw/cobigen/maven/GenerateMojo.java
+++ b/cobigen-maven/cobigen-maven-plugin/src/main/java/com/devonfw/cobigen/maven/GenerateMojo.java
@@ -221,7 +221,8 @@ public class GenerateMojo extends AbstractMojo {
                 getLog().error("Could not add configuration folder " + configurationFolder.toString(), e);
             }
         }
-        Path rootPath = null;
+
+        Path rootPath;
         URL rootUrl = classRealm.getResource("context.xml");
         if (rootUrl == null) {
             rootUrl = classRealm.getResource("src/main/templates/context.xml");
@@ -231,6 +232,8 @@ public class GenerateMojo extends AbstractMojo {
             } else {
                 rootPath = Paths.get(URI.create(rootUrl.toString())).getParent().getParent().getParent();
             }
+        } else {
+            rootPath = Paths.get(URI.create(rootUrl.toString()));
         }
         getLog().debug("Found context.xml @ " + rootUrl.toString());
         final List<String> foundClasses = new LinkedList<>();


### PR DESCRIPTION
Adresses #704 .
Dependent on #726 

Implements

* Dependency to latest core version in pom
* modified util class reading so the correct root path is used even when the context.xml file is only found in src/main/templates