### PR TITLE
Maven build error #715

### DIFF
--- a/cobigen-maven/cobigen-maven-systemtest/src/test/java/com/devonfw/cobigen/maven/systemtest/Oasp4JTemplateTest.java
+++ b/cobigen-maven/cobigen-maven-systemtest/src/test/java/com/devonfw/cobigen/maven/systemtest/Oasp4JTemplateTest.java
@@ -80,6 +80,26 @@ public class Oasp4JTemplateTest extends AbstractMavenTest {
     }
 
     /**
+     * Tries to reproduce issue #715 https://github.com/devonfw/tools-cobigen/issues/715 where a Windows path
+     * exception is thrown when trying to generate from an OpenApi file. For doing so, processes a generation
+     * of oasp4j template increments daos, entity_infrastructure, TOs, Logic and Rest Service and just checks
+     * whether the files have been generated. Takes a yaml file as input.
+     * @throws Exception
+     *             test fails
+     */
+    @Test
+    public void testWindowsPathGenerationError() throws Exception {
+        File testProject = new File(TEST_RESOURCES_ROOT + "TestWindowsPathGenerationError/");
+        File testProjectRoot = runMavenInvoker(testProject, MavenMetadata.LOCAL_REPO);
+
+        long numFilesInTarget =
+            Files.walk(testProjectRoot.toPath().resolve("src")).filter(Files::isRegularFile).count();
+        // 4 from from daos + 4 from entity infrastructure + 6 from TOs + 4 from Logic (all in one) + 2 rest
+        // service imp = 18
+        assertThat(numFilesInTarget).isEqualTo(18);
+    }
+
+    /**
      * Test class loading for a configuration folder with java util classes as well as test classes
      * @throws Exception
      *             test fails

--- a/cobigen-maven/cobigen-maven-systemtest/src/test/resources/testdata/systemtest/Oasp4JTemplateTest/TestEntityInputDataaccessGeneration/pom.xml
+++ b/cobigen-maven/cobigen-maven-systemtest/src/test/resources/testdata/systemtest/Oasp4JTemplateTest/TestEntityInputDataaccessGeneration/pom.xml
@@ -33,7 +33,7 @@
           <dependency>
             <groupId>com.devonfw.cobigen</groupId>
             <artifactId>templates-oasp4j</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>2.4.3</version>
           </dependency>
           <dependency>
             <groupId>com.devonfw.cobigen</groupId>
@@ -48,12 +48,12 @@
           <dependency>
             <groupId>com.devonfw.cobigen</groupId>
             <artifactId>xmlplugin</artifactId>
-            <version>3.2.0-SNAPSHOT</version>
+            <version>3.2.0</version>
           </dependency>
           <dependency>
             <groupId>com.devonfw.cobigen</groupId>
             <artifactId>openapiplugin</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.0.0</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/cobigen-maven/cobigen-maven-systemtest/src/test/resources/testdata/systemtest/Oasp4JTemplateTest/TestPackageInputDataaccessGeneration/pom.xml
+++ b/cobigen-maven/cobigen-maven-systemtest/src/test/resources/testdata/systemtest/Oasp4JTemplateTest/TestPackageInputDataaccessGeneration/pom.xml
@@ -33,7 +33,7 @@
           <dependency>
             <groupId>com.devonfw.cobigen</groupId>
             <artifactId>templates-oasp4j</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>2.4.3</version>
           </dependency>
           <dependency>
             <groupId>com.devonfw.cobigen</groupId>
@@ -53,7 +53,7 @@
           <dependency>
             <groupId>com.devonfw.cobigen</groupId>
             <artifactId>openapiplugin</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.0.0</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/cobigen-maven/cobigen-maven-systemtest/src/test/resources/testdata/systemtest/Oasp4JTemplateTest/TestWindowsPathGenerationError/devonfw.yml
+++ b/cobigen-maven/cobigen-maven-systemtest/src/test/resources/testdata/systemtest/Oasp4JTemplateTest/TestWindowsPathGenerationError/devonfw.yml
@@ -1,0 +1,115 @@
+openapi: 3.0.0
+servers:
+  - url: 'https://localhost:8081/server/services/rest'
+    description: Just some data
+info:
+  title: Devon Example
+  description: Example of a API definition
+  version: 1.0.0
+  x-rootpackage: com.capgemini.spoc.openapi
+paths:
+  /shopmanagement/v1/shop/{shopId}:
+    get:
+      operationId: findShop
+      parameters:
+        - name: shopId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+            maximum: 50
+      responses:
+        '200':
+          description: Any
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Shop'
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: Not found
+  /salemanagement/v1/sale/{saleId}:
+    get:
+      operationId: findSale
+      parameters:
+        - name: saleId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Any
+  /salemanagement/v1/sale/{bla}:
+    get:
+      operationId: findSale
+      parameters:
+        - name: bla
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 10
+            maximum: 200
+      responses:
+        '200':
+          description: Any
+  /salemanagement/v1/sale/:
+    post:
+      responses:
+        '200':
+          description: Any
+      requestBody:
+        $ref: '#/components/requestBodies/ShopData'
+      tags:
+       - searchCriteria
+  /shopmanagement/v1/shop/new:
+    post:
+      responses:
+       '200':
+          description: Any
+      requestBody:
+        $ref: '#/components/requestBodies/ShopData'
+components:
+    schemas:
+        Shop:
+          x-component: shopmanagement
+          description: Entity definiton of Shop
+          type: object
+          properties:
+            shopExample:
+              type: string
+              maxLength: 100
+              minLength: 5
+              uniqueItems: true
+          x-manytomany: Shop
+          x-onetoone: Sale
+        Sale:
+          x-component: salemanagement
+          description: Entity definiton of Shop
+          type: object
+          properties:
+            saleExample:
+              type: number
+              format: int64
+              maximum: 100
+              minimum: 0
+          x-onetoone: Shop
+          x-onetomany: Shop
+          required:
+            - saleExample
+
+    requestBodies:
+        ShopData:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Shop'
+          required: true
+ 

--- a/cobigen-maven/cobigen-maven-systemtest/src/test/resources/testdata/systemtest/Oasp4JTemplateTest/TestWindowsPathGenerationError/pom.xml
+++ b/cobigen-maven/cobigen-maven-systemtest/src/test/resources/testdata/systemtest/Oasp4JTemplateTest/TestWindowsPathGenerationError/pom.xml
@@ -1,0 +1,66 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.capgemini</groupId>
+	<artifactId>apigendemo</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Api Generation</name>
+
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.devonfw.cobigen</groupId>
+				<artifactId>maven-plugin</artifactId>
+				<version>4.0.0</version>
+				<executions>
+					<execution>
+						<id>generate</id>
+						<phase>package</phase>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<inputFiles>
+						<inputFile>TeacherEto.java</inputFile>
+					</inputFiles>
+					<increments>
+						<increment>app_ionic_structure</increment>
+					</increments>
+					<failOnNothingGenerated>false</failOnNothingGenerated>
+				</configuration>
+				<dependencies>
+				    <dependency>
+						<groupId>com.devonfw.cobigen</groupId>
+						<artifactId>templates-oasp4j</artifactId>
+						<version>2.4.1</version>
+					</dependency>		
+					<dependency>
+						<groupId>com.devonfw.cobigen</groupId>
+						<artifactId>tempeng-freemarker</artifactId>
+						<version>2.0.0</version>
+					</dependency>
+					<dependency>
+						<groupId>com.devonfw.cobigen</groupId>
+						<artifactId>xmlplugin</artifactId>
+						<version>4.0.0</version>
+					</dependency>
+					<dependency>
+						<groupId>com.devonfw.cobigen</groupId>
+						<artifactId>openapiplugin</artifactId>
+						<version>2.0.0</version>
+					</dependency>
+					<dependency>
+						<groupId>com.devonfw.cobigen</groupId>
+						<artifactId>javaplugin</artifactId>
+						<version>2.0.0</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/cobigen-maven/cobigen-maven-test/src/main/java/com/devonfw/cobigen/maven/test/AbstractMavenTest.java
+++ b/cobigen-maven/cobigen-maven-test/src/main/java/com/devonfw/cobigen/maven/test/AbstractMavenTest.java
@@ -88,7 +88,7 @@ public class AbstractMavenTest {
 
         InvocationRequest request = new DefaultInvocationRequest();
         request.setBaseDirectory(testProjectRoot);
-        request.setGoals(Collections.singletonList("package -X"));
+        request.setGoals(Collections.singletonList("package"));
         setTestProperties(request, templatesProject);
         request.getProperties().put("locRep", localRepoPath);
         request.setShowErrors(true);

--- a/cobigen-maven/cobigen-maven-test/src/main/java/com/devonfw/cobigen/maven/test/AbstractMavenTest.java
+++ b/cobigen-maven/cobigen-maven-test/src/main/java/com/devonfw/cobigen/maven/test/AbstractMavenTest.java
@@ -88,7 +88,7 @@ public class AbstractMavenTest {
 
         InvocationRequest request = new DefaultInvocationRequest();
         request.setBaseDirectory(testProjectRoot);
-        request.setGoals(Collections.singletonList("package"));
+        request.setGoals(Collections.singletonList("package -X"));
         setTestProperties(request, templatesProject);
         request.getProperties().put("locRep", localRepoPath);
         request.setShowErrors(true);


### PR DESCRIPTION
Adresses #715 .

This PR does not contain the solution to the bug stated on the issue. It just contains a test that I used to successfully reproduce the error.

Some things we found out:

* The bug arises when using templates-oasp4j version `2.4.1` onwards.
* The triggers are correctly read.
* When using a Java entity file as input, the generation is successful.

@devonfw/cobigen
