### PR TITLE
Kafka and REST documentation update

### DIFF
--- a/cobigen-templates/templates-oasp4j/pom.xml
+++ b/cobigen-templates/templates-oasp4j/pom.xml
@@ -25,6 +25,11 @@
       <version>2.0</version>
     </dependency>
     <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-rest-webmvc</artifactId>
+      <version>3.0.9.RELEASE</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.5</version>

--- a/cobigen-templates/templates-oasp4j/src/main/java/com/devonfw/cobigen/templates/oasp4j/utils/documentation/JavaDocumentationUtil.java
+++ b/cobigen-templates/templates-oasp4j/src/main/java/com/devonfw/cobigen/templates/oasp4j/utils/documentation/JavaDocumentationUtil.java
@@ -8,6 +8,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -22,6 +23,15 @@ import com.fasterxml.jackson.databind.SerializationFeature;
  *
  */
 public class JavaDocumentationUtil {
+
+    /** Full qualified name of spring RequestMapping annotation */
+    private final String requestMapping = "org_springframework_web_bind_annotation_RequestMapping";
+
+    /** Full qualified name of javax Path annotation */
+    private final String javaxPath = "javax_ws_rs_Path";
+
+    // /** Logger instance. */
+    // private static final Logger LOG = LoggerFactory.getLogger(JavaDocumentationUtil.class);
 
     /**
      * Creates a list of parameters of a specific method as an asciidoc string, including its name, type,
@@ -130,16 +140,7 @@ public class JavaDocumentationUtil {
     public String getJSONResponseBody(Class<?> pojoClass, String methodName) throws Exception {
         Class<?> responseType = findMethod(pojoClass, methodName).getReturnType();
         if (hasBody(pojoClass, methodName, true)) {
-            ObjectMapper mapper = new ObjectMapper();
-            mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
-            mapper.enable(SerializationFeature.INDENT_OUTPUT);
-            try {
-                Object obj = responseType.newInstance();
-                return "...." + System.lineSeparator() + mapper.writeValueAsString(obj) + System.lineSeparator()
-                    + "....";
-            } catch (InstantiationException | IllegalAccessException | JsonProcessingException e) {
-                throw new Exception(e.getMessage());
-            }
+            return getJSON(responseType);
         }
         return "-";
     }
@@ -159,18 +160,29 @@ public class JavaDocumentationUtil {
         if (hasBody(pojoClass, methodName, false)) {
             Parameter param = m.getParameters()[0];
             Class<?> requestType = param.getType();
-            ObjectMapper mapper = new ObjectMapper();
-            mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
-            mapper.enable(SerializationFeature.INDENT_OUTPUT);
-            try {
-                Object obj = requestType.newInstance();
-                return "...." + System.lineSeparator() + mapper.writeValueAsString(obj) + System.lineSeparator()
-                    + "....";
-            } catch (InstantiationException | IllegalAccessException | JsonProcessingException e) {
-                throw new Exception(e.getMessage());
-            }
+            return getJSON(requestType);
         }
         return "-";
+    }
+
+    /**
+     * Using Jackson, creates a JSON string for Asciidoc
+     * @param clazz
+     *            The class to create the JSON string of
+     * @return A JSON representation of the given class
+     * @throws Exception
+     *             When Jackson fails
+     */
+    public String getJSON(Class<?> clazz) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        try {
+            Object obj = clazz.newInstance();
+            return "...." + System.lineSeparator() + mapper.writeValueAsString(obj) + System.lineSeparator() + "....";
+        } catch (InstantiationException | IllegalAccessException | JsonProcessingException e) {
+            throw new Exception(e.getMessage());
+        }
     }
 
     /**
@@ -217,22 +229,96 @@ public class JavaDocumentationUtil {
     }
 
     /**
+     * returns the HTTP request type corresponding to an annotation type
+     * @param annotations
+     *            The annotation to get the type name of
+     * @return the HTTP request type name of the selected annotation
+     */
+    public String getRequestType(Map<String, Object> annotations) {
+        String type = "";
+        if (annotations.containsKey(requestMapping)) {
+            Map<String, Object> method = (Map<String, Object>) annotations.get(requestMapping);
+            String rm = (String) method.get("method");
+            type = rm.toLowerCase();
+        }
+        if (annotations.containsKey("javax_ws_rs_GET") || type.equals("requestmethod.get")) {
+            return "GET";
+        } else if (annotations.containsKey("javax_ws_rs_PUT") || type.equals("requestmethod.put")) {
+            return "PUT";
+        } else if (annotations.containsKey("javax_ws_rs_POST") || type.equals("requestmethod.post")) {
+            return "POST";
+        } else if (annotations.containsKey("javax_ws_rs_DELETE") || type.equals("requestmethod.delete")) {
+            return "DELETE";
+        } else if (annotations.containsKey("javax_ws_rs_PATCH") || type.equals("requestmethod.patch")) {
+            return "PATCH";
+        } else {
+            return "-";
+        }
+    }
+
+    /**
+     * Gets the path of an operation
+     * @param pojoAnnotations
+     *            the annotation map of the given pojo
+     * @param method
+     *            The method to get the operation path of
+     * @return The path of an operation
+     * @throws IOException
+     *             If no application_properties file is found
+     */
+    public String getOperationPath(Map<String, Object> pojoAnnotations, Map<String, Object> method) throws IOException {
+        String path = getPath(pojoAnnotations);
+        Map<String, Object> pathAnno = new HashMap<>();
+        if (pojoAnnotations.containsKey(javaxPath)) {
+            pathAnno = (Map<String, Object>) pojoAnnotations.get(javaxPath);
+        } else if (pojoAnnotations.containsKey(requestMapping)) {
+            pathAnno = (Map<String, Object>) pojoAnnotations.get(requestMapping);
+        }
+        if (pathAnno.containsKey("value")) {
+            String toAdd = (String) pathAnno.get("value");
+            if (toAdd.startsWith("/") && path.endsWith("/")) {
+                path += toAdd.substring(1);
+            }
+        }
+        return path;
+    }
+
+    /**
+     * Gets the path of a component
+     * @param pojoAnnotations
+     *            the annotation map of the given pojo
+     * @return The communal path of a component
+     * @throws IOException
+     *             If no application_properties file is found
+     */
+    public String getPath(Map<String, Object> pojoAnnotations) throws IOException {
+        String path = extractRootPath();
+        Map<String, Object> pathAnno = new HashMap<>();
+        if (pojoAnnotations.containsKey(javaxPath)) {
+            pathAnno = (Map<String, Object>) pojoAnnotations.get(javaxPath);
+        } else if (pojoAnnotations.containsKey(requestMapping)) {
+            pathAnno = (Map<String, Object>) pojoAnnotations.get(requestMapping);
+        }
+        if (pathAnno.containsKey("value")) {
+            String toAdd = (String) pathAnno.get("value");
+            if (toAdd.startsWith("/") && path.endsWith(":")) {
+                path += toAdd.substring(1);
+            }
+        }
+        return path;
+    }
+
+    /**
      * Checks the class path for an application.properties file and extracts the port and path from it
-     * @param pojoClass
-     *            {@link Class}&lt;?> the class object of the pojo
      * @return The root path of the application
      * @throws IOException
      *             If no application.properties file could be found
      */
-    public String extractRootPath(Class<?> pojoClass) throws IOException {
-
-        if (pojoClass == null) {
-            throw new IllegalAccessError(
-                "Class object is null. Cannot generate template as it might obviously depend on reflection.");
-        }
+    private String extractRootPath() throws IOException {
+        Class<?> clazz = this.getClass();
         String t = "";
         StringBuilder sb = new StringBuilder("http://localhost:");
-        InputStream in = pojoClass.getClassLoader().getResourceAsStream("application.properties");
+        InputStream in = clazz.getClassLoader().getResourceAsStream("application.properties");
         if (in != null) {
             BufferedReader br = new BufferedReader(new InputStreamReader(in));
             while ((t = br.readLine()) != null) {
@@ -242,7 +328,8 @@ public class JavaDocumentationUtil {
             }
             return sb.toString();
         } else {
-            throw new IOException("application.properties file not found!");
+            return "http://localhost:";
+            // throw new IOException("application.properties file not found!");
         }
     }
 

--- a/cobigen-templates/templates-oasp4j/src/main/java/com/devonfw/cobigen/templates/oasp4j/utils/documentation/JavaDocumentationUtil.java
+++ b/cobigen-templates/templates-oasp4j/src/main/java/com/devonfw/cobigen/templates/oasp4j/utils/documentation/JavaDocumentationUtil.java
@@ -30,9 +30,6 @@ public class JavaDocumentationUtil {
     /** Full qualified name of javax Path annotation */
     private final String javaxPath = "javax_ws_rs_Path";
 
-    // /** Logger instance. */
-    // private static final Logger LOG = LoggerFactory.getLogger(JavaDocumentationUtil.class);
-
     /**
      * Creates a list of parameters of a specific method as an asciidoc string, including its name, type,
      * description, constraints
@@ -328,8 +325,7 @@ public class JavaDocumentationUtil {
             }
             return sb.toString();
         } else {
-            return "http://localhost:";
-            // throw new IOException("application.properties file not found!");
+            return "";
         }
     }
 

--- a/cobigen-templates/templates-oasp4j/src/main/templates/documentation/kafka/templates/docs/${variables.component}To.adoc.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/documentation/kafka/templates/docs/${variables.component}To.adoc.ftl
@@ -4,36 +4,30 @@
 Component Data
 [options="header"]
 |===
-|Name |Description |Consumes |Produces
+|Name |Description |Topic
 |${variables.component?cap_first}
 |<#if pojo.javaDoc??>${JavaDocumentationUtil.getJavaDocWithoutLink(pojo.javaDoc.comment)}<#else>No javaDoc available</#if>
-|<#if pojo.javaDoc.topic??>${JavaDocumentationUtil.getJavaDocWithoutLink(pojo.javaDoc.topic)}<#else>No topic defined</#if>
+|<#if pojo.javaDoc??><#if pojo.javaDoc.topic??>${JavaDocumentationUtil.getJavaDocWithoutLink(pojo.javaDoc.topic)}<#else>-</#if><#else>-</#if>
 |===
     
 === Fields
-<#assign declared=false>  
-<#if pojo.fields?has_content>
-  <#list pojo.fields as field>
-    <#if field.javaDoc??>
-      <#compress>
-      <#if !declared>
-        [options="header"]
-        |===
-        |Member name |javaDoc |Value |Required |Example |Datatype |Allows Empty Value
-        <#assign declared=true>
-      </#if>
-      |${field.name}
-      |${JavaDocumentationUtil.getJavaDocWithoutLink(field.javaDoc.comment)}
-      |<#if field.javaDoc.value??>${JavaDocumentationUtil.getJavaDocWithoutLink(field.javaDoc.value)}<#else>-</#if>
-      |<#if field.javaDoc.required??>${JavaDocumentationUtil.getJavaDocWithoutLink(field.javaDoc.required)}<#else>-</#if>
-      |<#if field.javaDoc.example??>${JavaDocumentationUtil.getJavaDocWithoutLink(field.javaDoc.example)}<#else>-</#if>
-      |<#if field.javaDoc.datatype??>${JavaDocumentationUtil.getJavaDocWithoutLink(field.javaDoc.datatype)}<#else>-</#if>
-      |<#if field.javaDoc.emptyvalue??>${JavaDocumentationUtil.getJavaDocWithoutLink(field.javaDoc.emptyvalue)}<#else>-</#if>
-      </#compress>
-    </#if>
-  </#list>
-</#if>
-<#if declared>
+
+[cols="1s,5"]
 |===
-<#assign declared=true>
-</#if>
+|Body a|
+<#if pojo.fields?size gt 0>${JavaDocumentationUtil.getJSON(classObject)}<#else>-</#if>
+|Parameter list a|
+[options='header']
+!===
+!Name !Description !Datatype !Required !Example
+<#list pojo.fields as field>
+  <#compress>
+  !<#if field.name??>${field.name}<#else>-</#if>
+  !<#if field.javaDoc??>${JavaDocumentationUtil.getJavaDocWithoutLink(field.javaDoc.comment)}<#else>-</#if>
+  !<#if field.type??>${field.type}<#else>-</#if>
+  !<#if field.javaDoc??><#if field.javaDoc.required??>${field.javaDoc.required}<#else>-</#if><#else>-</#if>
+  !<#if field.javaDoc??><#if field.javaDoc.example??>${field.javaDoc.example}<#else>-</#if><#else>-</#if>
+  </#compress>
+</#list>
+!===
+|===

--- a/cobigen-templates/templates-oasp4j/src/main/templates/documentation/rest/templates/docs/${variables.component}RESTInterfaces.adoc.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/documentation/rest/templates/docs/${variables.component}RESTInterfaces.adoc.ftl
@@ -3,7 +3,7 @@
 
 **Component Service Path:** 
 ....
-${JavaDocumentationUtil.extractRootPath(classObject)}<#if pojo.annotations.javax_ws_rs_Path??>/${pojo.annotations.javax_ws_rs_Path.value}</#if>
+${JavaDocumentationUtil.getPath(pojo.annotations)}
 ....
 
 <#-- Determine body format -->
@@ -42,7 +42,7 @@ Component Data
       .${method.name}
       [cols='1s,6m']
       |===
-      |${DocumentationUtil.getTypeWithAsciidocColour(type)} |${JavaDocumentationUtil.extractRootPath(classObject)}${pojo.annotations.javax_ws_rs_Path.value}${method.annotations.javax_ws_rs_Path.value}
+      |${DocumentationUtil.getTypeWithAsciidocColour(type)} |${JavaDocumentationUtil.getOperationPath(pojo.annotations,method.annotations)}
       |Description |<#if method.javaDoc??>${JavaDocumentationUtil.getJavaDocWithoutLink(method.javaDoc.comment)}<#else>-</#if>
     
       <#if JavaDocumentationUtil.hasBody(classObject,method.name,false)>.2+<</#if>|Request 
@@ -78,3 +78,20 @@ ${JavaDocumentationUtil.getJSONResponseBody(classObject,method.name)}
     </#compress>
   </#if>
 </#list>
+
+<#function getPathEnding method>
+  <#if JavaDocumentationUtil.isNoString(method)>
+    <#if pojo.annotations.javax_ws_rs_Path?? && method.annotations.javax_ws_rs_Path??>
+      <#return (pojo.annotations.javax_ws_rs_Path.value+method.annotations.javax_ws_rs_Path.value)>
+    <#elseif pojo.annotations.org_springframework_web_bind_annotation_RequestMapping?? && method.annotations.org_springframework_web_bind_annotation_RequestMapping??>
+      <#return (pojo.annotations.org_springframework_web_bind_annotation_RequestMapping.path+method.annotations.org_springframework_web_bind_annotation_RequestMapping.path)>
+    </#if>
+  <#else>
+    <#if pojo.annotations.javax_ws_rs_Path??>
+      <#return pojo.annotations.javax_ws_rs_Path.value>
+    <#elseif pojo.annotations.org_springframework_web_bind_annotation_RequestMapping??>
+      <#return pojo.annotations.org_springframework_web_bind_annotation_RequestMapping.path>
+    </#if>
+  </#if>
+  <#return "">
+</#function>

--- a/cobigen-templates/templates-oasp4j/src/test/resources/testdata/templatetest/TestAllTemplatesRestServiceInput/pom.xml
+++ b/cobigen-templates/templates-oasp4j/src/test/resources/testdata/templatetest/TestAllTemplatesRestServiceInput/pom.xml
@@ -11,6 +11,11 @@
       <artifactId>javax.ws.rs-api</artifactId>
       <version>2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-rest-webmvc</artifactId>
+      <version>3.0.9.RELEASE</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -32,7 +37,8 @@
           <configurationFolder>${templatesProject}</configurationFolder>
           <inputFiles>
             <inputFile>src/main/java/io/github/devonfw/cobigen/generator/service/api/rest/InputNoAnnotationsRestService.java</inputFile>
-            <inputFile>src/main/java/io/github/devonfw/cobigen/generator/service/api/rest/InputRestService.java</inputFile>
+            <inputFile>src/main/java/io/github/devonfw/cobigen/generator/service/api/rest/JavaxAnnotationsInputRestService.java</inputFile>
+            <inputFile>src/main/java/io/github/devonfw/cobigen/generator/service/api/rest/SpringAnnotationsInputRestService.java</inputFile>
           </inputFiles>
           <templates>
             <template>ALL</template>
@@ -43,7 +49,7 @@
           <dependency>
             <groupId>com.devonfw.cobigen</groupId>
             <artifactId>tempeng-freemarker</artifactId>
-            <version>2.0.1-SNAPSHOT</version>
+            <version>2.0.0</version>
           </dependency>
           <dependency>
             <groupId>com.devonfw.cobigen</groupId>

--- a/cobigen-templates/templates-oasp4j/src/test/resources/testdata/templatetest/TestAllTemplatesRestServiceInput/src/main/java/io/github/devonfw/cobigen/generator/service/api/rest/JavaxAnnotationsInputRestService.java
+++ b/cobigen-templates/templates-oasp4j/src/test/resources/testdata/templatetest/TestAllTemplatesRestServiceInput/src/main/java/io/github/devonfw/cobigen/generator/service/api/rest/JavaxAnnotationsInputRestService.java
@@ -12,7 +12,7 @@ import javax.ws.rs.core.MediaType;
 @Path("/test/v1")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
-public interface InputRestService {
+public interface JavaxAnnotationsInputRestService {
 
   /**
    * Delegates to nothing.

--- a/cobigen-templates/templates-oasp4j/src/test/resources/testdata/templatetest/TestAllTemplatesRestServiceInput/src/main/java/io/github/devonfw/cobigen/generator/service/api/rest/SpringAnnotationsInputRestService.java
+++ b/cobigen-templates/templates-oasp4j/src/test/resources/testdata/templatetest/TestAllTemplatesRestServiceInput/src/main/java/io/github/devonfw/cobigen/generator/service/api/rest/SpringAnnotationsInputRestService.java
@@ -1,0 +1,38 @@
+package io.github.devonfw.cobigen.generator.service.api.rest;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@RequestMapping("/test/v1")
+public interface SpringAnnotationsInputRestService {
+
+    /**
+     * Delegates to nothing.
+     *
+     * @param id
+     *            the ID of nothing
+     * @return nothing really
+     */
+    @RequestMapping(path = "/test1/{id}/", method = RequestMethod.GET)
+    public String getVisitor(long id);
+
+    /**
+     * Delegates to nothing.
+     *
+     * @param nothing
+     *            actually
+     * @return apparently a String
+     */
+    @RequestMapping(path = "/test/", method = RequestMethod.POST)
+    public String saveVisitor(String test);
+
+    /**
+     * Delegates to nothing.
+     *
+     * @param id
+     *            ID of nothing to be deleted
+     */
+    @RequestMapping(path = "/test2/{id}/", method = RequestMethod.DELETE)
+    public void deleteVisitor(long id);
+
+}


### PR DESCRIPTION
Adresses #548.

Implements

* Updated structure and contained data of kafka documentation
* Added support for Spring REST annotations in RestService generation
* Modified extractRootPath so it doesn't cause builds to fail anymore
* Refactored some util methods