### PR TITLE
#749 fixing CRUD logic complex increment

### DIFF
--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_java_server_app_complex/templates/java/${variables.rootPackage}/${variables.component}/logic/api/usecase/UcFind${variables.entityName}.java.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_java_server_app_complex/templates/java/${variables.rootPackage}/${variables.component}/logic/api/usecase/UcFind${variables.entityName}.java.ftl
@@ -25,4 +25,19 @@ public interface UcFind${variables.entityName} {
    */
   PaginatedListTo<${variables.entityName}Eto> find${variables.entityName}Etos(${variables.entityName}SearchCriteriaTo criteria);
 
+  /**
+   * Returns a composite ${variables.entityName} by its id 'id'.
+   *
+   * @param id The id 'id' of the ${variables.entityName}.
+   * @return The {@link ${variables.entityName}Cto} with id 'id'
+   */
+  ${variables.entityName}Cto find${variables.entityName}Cto(Long id);
+  
+  /**
+   * Returns a paginated list of composite ${variables.entityName}s matching the search criteria.
+   *
+   * @param criteria the {@link ${variables.entityName}SearchCriteriaTo}.
+   * @return the {@link List} of matching {@link ${variables.entityName}Cto}s.
+   */
+  PaginatedListTo<${variables.entityName}Cto> find${variables.entityName}Ctos(${variables.entityName}SearchCriteriaTo criteria);
 }

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_java_server_app_complex/templates/java/${variables.rootPackage}/${variables.component}/logic/impl/${variables.component#cap_first}Impl.java.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_java_server_app_complex/templates/java/${variables.rootPackage}/${variables.component}/logic/impl/${variables.component#cap_first}Impl.java.ftl
@@ -44,6 +44,17 @@ public class ${variables.component?cap_first}Impl extends AbstractComponentFacad
     }
 
     @Override
+    public ${variables.entityName}Cto find${variables.entityName}Cto(Long id) {
+
+      return this.ucFind${variables.entityName}.find${variables.entityName}Cto(id);
+    }
+
+    @Override
+    public PaginatedListTo<${variables.entityName}Cto> find${variables.entityName}Ctos(${variables.entityName}SearchCriteriaTo criteria) {
+      return this.ucFind${variables.entityName}.find${variables.entityName}Ctos(criteria);
+    }
+
+    @Override
     public ${variables.entityName}Eto save${variables.entityName}(${variables.entityName}Eto ${variables.entityName?lower_case}) {
 
       return this.ucManage${variables.entityName}.save${variables.entityName}(${variables.entityName?lower_case});

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_java_server_app_complex/templates/java/${variables.rootPackage}/${variables.component}/logic/impl/usecase/UcFind${variables.entityName}Impl.java.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_java_server_app_complex/templates/java/${variables.rootPackage}/${variables.component}/logic/impl/usecase/UcFind${variables.entityName}Impl.java.ftl
@@ -43,4 +43,44 @@ public class UcFind${variables.entityName}Impl extends Abstract${variables.entit
       return mapPaginatedEntityList(${variables.entityName?lower_case}s, ${variables.entityName}Eto.class);
   }
 
+  @Override
+  public ${variables.entityName}Cto find${variables.entityName}Cto(Long id) {
+    LOG.debug("Get ${variables.entityName}Cto with id {} from database.", id);
+    ${variables.entityName}Entity entity = get${variables.entityName}Dao().findOne(id);
+    ${variables.entityName}Cto cto = new ${variables.entityName}Cto();
+    cto.set${variables.entityName?cap_first}(getBeanMapper().map(entity, ${variables.entityName}Eto.class));
+    <#list pojo.fields as field>
+      <#if field.type?ends_with("Entity")>
+    cto.set${field.name?cap_first}(getBeanMapper().map(entity.get${field.name?cap_first}(), ${field.type?replace("Entity", "Eto")}.class));
+      <#elseif field.type?contains("Entity") && JavaUtil.isCollection(classObject, field.name)>
+    cto.set${field.name?cap_first}(getBeanMapper().mapList(entity.get${field.name?cap_first}(), ${OaspUtil.getListArgumentType(field, classObject)}Eto.class));
+      </#if>
+    </#list>
+ 
+    return cto;
+  }
+
+  @Override
+  public PaginatedListTo<${variables.entityName}Cto> find${variables.entityName}Ctos(${variables.entityName}SearchCriteriaTo criteria) {
+    criteria.limitMaximumPageSize(MAXIMUM_HIT_LIMIT);
+    PaginatedListTo<${variables.entityName}Entity> ${variables.entityName?lower_case}s = get${variables.entityName}Dao().find${variables.entityName}s(criteria);
+    List<${variables.entityName}Cto> ctos = new ArrayList<>();
+    for (${variables.entityName}Entity entity : ${variables.entityName?lower_case}s.getResult()) {
+      ${variables.entityName}Cto cto = new ${variables.entityName}Cto();
+      cto.set${variables.entityName?cap_first}(getBeanMapper().map(entity, ${variables.entityName}Eto.class));
+      <#list pojo.fields as field>
+        <#if field.type?ends_with("Entity")>
+      cto.set${field.name?cap_first}(getBeanMapper().map(entity.get${field.name?cap_first}(), ${field.type?replace("Entity", "Eto")}.class));
+        <#elseif field.type?contains("Entity") && JavaUtil.isCollection(classObject, field.name)>
+      cto.set${field.name?cap_first}(getBeanMapper().mapList(entity.get${field.name?cap_first}(), ${OaspUtil.getListArgumentType(field, classObject)}Eto.class));
+        </#if>
+      </#list>
+      ctos.add(cto);
+      
+    }
+    PaginationResultTo pagResultTo = new PaginationResultTo(criteria.getPagination(), (long) ctos.size());
+    PaginatedListTo<${variables.entityName}Cto> pagListTo = new PaginatedListTo(ctos, pagResultTo);
+    return pagListTo;
+  }
+
 }


### PR DESCRIPTION
Addresses #749.

This pull request just tries to fix the compilation errors related to `CRUD Logic (with use cases)` increment. It does not include any SWT Bot test. However, I would like to quickly fix this by publishing the template changes on a new accumulative patch for devonfw.

**Implements**

Increment `CRUD Logic (with use cases)` had a compilation error related to `${entityName}Cto` not defining `find${entityName}Cto` method. I have added this method into UcFind${variables.entityName}Impl.java template because I thought it made sense to have it on this use case as it is called "Find".

@devonfw/cobigen
