### PR TITLE
Angular templates to devon4j 3.0.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,7 @@ node {
 								if(origin_branch == 'master') {
 									// https://github.com/jenkinsci/xvnc-plugin/blob/master/src/main/java/hudson/plugins/xvnc/Xvnc.java
 									wrap([$class:'Xvnc', useXauthority: true]) { // takeScreenshot: true, causes issues seemingly
-										export SWT_GTK3=0 // disable GTK3 as of linux bug (see also https://bbs.archlinux.org/viewtopic.php?id=218587)
+										sh 'export SWT_GTK3=0' // disable GTK3 as of linux bug (see also https://bbs.archlinux.org/viewtopic.php?id=218587)
 										sh "mvn -s ${MAVEN_SETTINGS} clean install -U -Pp2-build-mars,p2-build-stable"
 									}
 								} else if (origin_branch == 'dev_eclipseplugin') {
@@ -170,7 +170,7 @@ node {
 								// load jenkins managed global maven settings file
 								configFileProvider([configFile(fileId: '9d437f6e-46e7-4a11-a8d1-2f0055f14033', variable: 'MAVEN_SETTINGS')]) {
 									try {
-										export SWT_GTK3=0 // disable GTK3 as of linux bug (see also https://bbs.archlinux.org/viewtopic.php?id=218587)
+										sh 'export SWT_GTK3=0' // disable GTK3 as of linux bug (see also https://bbs.archlinux.org/viewtopic.php?id=218587)
 										sh "mvn -s ${MAVEN_SETTINGS} integration-test -Pp2-build-mars,p2-build-ci"
 									} catch(err) {
 										step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/*.xml', allowEmptyResults: false])

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/cobigen.properties
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/cobigen.properties
@@ -1,1 +1,1 @@
-relocate:../../oasp4js-application-template/${cwd}
+relocate:../../devon4ng-application-template/${cwd}

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/src/app/${variables.etoName#lower_case}/${variables.etoName#lower_case}-grid/${variables.etoName#lower_case}-grid.component.html.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/src/app/${variables.etoName#lower_case}/${variables.etoName#lower_case}-grid/${variables.etoName#lower_case}-grid.component.html.ftl
@@ -15,7 +15,7 @@
         <mat-icon>delete</mat-icon>
       </button>
 
-      <form (ngSubmit)="get${variables.etoName?cap_first}()" #filterForm="ngForm">
+      <form (ngSubmit)="filter()" #filterForm="ngForm">
         <td-expansion-panel label="Filters">
           <div layout="row" class="pad-left-md pad-right-md" style="align-items:center; border-bottom: 1px solid lightgrey" flex>
             <div layout-xs="column" class="justify-space-around" style="align-items:center" hide-gt-xs flex>

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/src/app/${variables.etoName#lower_case}/${variables.etoName#lower_case}-grid/${variables.etoName#lower_case}-grid.component.ts.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/src/app/${variables.etoName#lower_case}/${variables.etoName#lower_case}-grid/${variables.etoName#lower_case}-grid.component.ts.ftl
@@ -5,6 +5,7 @@ import {
   TdDialogService,
   IPageChangeEvent,
   ITdDataTableSortChangeEvent,
+  TdPagingBarComponent,
 } from '@covalent/core';
 import { MatDialogRef, MatDialog } from '@angular/material';
 import { Router } from '@angular/router';
@@ -21,6 +22,9 @@ import { Pageable } from '../../core/interfaces/pageable';
   styleUrls: ['./${variables.etoName?lower_case}-grid.component.scss'],
 })
 export class ${variables.etoName?cap_first}GridComponent implements OnInit {
+    @ViewChild('pagingBar')
+    pagingBar: TdPagingBarComponent;
+    
     private pageable: Pageable = {
         pageSize: 8,
         pageNumber: 0,
@@ -230,6 +234,11 @@ export class ${variables.etoName?cap_first}GridComponent implements OnInit {
           );
         }
       });
+  }
+  
+  filter(): void {
+    this.getSampleData();
+    this.pagingBar.firstPage();
   }
 
   searchReset(form: any): void {

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/src/app/${variables.etoName#lower_case}/${variables.etoName#lower_case}-grid/${variables.etoName#lower_case}-grid.component.ts.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/src/app/${variables.etoName#lower_case}/${variables.etoName#lower_case}-grid/${variables.etoName#lower_case}-grid.component.ts.ftl
@@ -237,7 +237,6 @@ export class ${variables.etoName?cap_first}GridComponent implements OnInit {
   }
   
   filter(): void {
-    this.get${variables.etoName?cap_first}();
     this.pagingBar.firstPage();
   }
 

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/src/app/${variables.etoName#lower_case}/${variables.etoName#lower_case}-grid/${variables.etoName#lower_case}-grid.component.ts.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/src/app/${variables.etoName#lower_case}/${variables.etoName#lower_case}-grid/${variables.etoName#lower_case}-grid.component.ts.ftl
@@ -13,7 +13,7 @@ import { ${variables.etoName?cap_first}Service } from '../services/${variables.e
 import { AuthService } from '../../core/security/auth.service';
 
 import { ${variables.etoName?cap_first}DialogComponent } from '../${variables.etoName?lower_case}-dialog/${variables.etoName?lower_case}-dialog.component';
-import { Pagination } from '../../core/interfaces/pagination';
+import { Pageable } from '../../core/interfaces/pageable';
 
 @Component({
   selector: 'public-${variables.etoName?lower_case}-grid',
@@ -21,11 +21,14 @@ import { Pagination } from '../../core/interfaces/pagination';
   styleUrls: ['./${variables.etoName?lower_case}-grid.component.scss'],
 })
 export class ${variables.etoName?cap_first}GridComponent implements OnInit {
-  private pagination: Pagination = {
-    size: 8,
-    page: 1,
-    total: 1,
-  };
+    private pageable: Pageable = {
+        pageSize: 8,
+        pageNumber: 0,
+        sort: [{
+            property: '${pojo.fields[0].name!}',
+            direction: 'ASC'
+        }]
+    };
   private sorting: any[] = [];
 
   @ViewChild('dataTable') dataTable: TdDataTableComponent;
@@ -67,15 +70,15 @@ export class ${variables.etoName?cap_first}GridComponent implements OnInit {
   get${variables.etoName?cap_first}(): void {
     this.dataGridService
       .get${variables.etoName?cap_first}(
-        this.pageSize,
-        this.pagination.page,
+        this.pageable.pageSize,
+        this.pageable.pageNumber,
         this.searchTerms,
-        this.sorting,
+        this.pageable.sort = this.sorting,
       )
       .subscribe(
         (res: any) => {
-          this.data = res.result;
-          this.totalItems = res.pagination.total;
+          this.data = res.content;
+          this.totalItems = res.totalElements;
           this.dataTable.refresh();
         },
         (error: any) => {
@@ -111,10 +114,10 @@ export class ${variables.etoName?cap_first}GridComponent implements OnInit {
   }
 
   page(pagingEvent: IPageChangeEvent): void {
-    this.pagination = {
-      size: pagingEvent.pageSize,
-      page: pagingEvent.page,
-      total: 1,
+    this.pageable = {
+        pageSize: pagingEvent.pageSize,
+        pageNumber: pagingEvent.page - 1,
+        sort: this.pageable.sort,
     };
     this.get${variables.etoName?cap_first}();
   }
@@ -122,7 +125,7 @@ export class ${variables.etoName?cap_first}GridComponent implements OnInit {
   sort(sortEvent: ITdDataTableSortChangeEvent): void {
     this.sorting = [];
     this.sorting.push({
-     name: sortEvent.name.split('.').pop(),
+     property: sortEvent.name.split('.').pop(),
      direction: '' + sortEvent.order,
     });
     this.get${variables.etoName?cap_first}();

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/src/app/${variables.etoName#lower_case}/${variables.etoName#lower_case}-grid/${variables.etoName#lower_case}-grid.component.ts.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/src/app/${variables.etoName#lower_case}/${variables.etoName#lower_case}-grid/${variables.etoName#lower_case}-grid.component.ts.ftl
@@ -237,7 +237,7 @@ export class ${variables.etoName?cap_first}GridComponent implements OnInit {
   }
   
   filter(): void {
-    this.getSampleData();
+    this.get${variables.etoName?cap_first}();
     this.pagingBar.firstPage();
   }
 

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/src/app/${variables.etoName#lower_case}/services/${variables.etoName#lower_case}.service.ts.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/src/app/${variables.etoName#lower_case}/services/${variables.etoName#lower_case}.service.ts.ftl
@@ -2,7 +2,10 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
 import { Observable } from 'rxjs';
-import { PageData } from '../../core/interfaces/page-data';
+import { SearchCriteria } from '../../core/interfaces/search-criteria';
+import { Sort } from '../../core/interfaces/sort';
+import { Pageable } from '../../core/interfaces/pageable';
+
 
 @Injectable()
 export class ${variables.etoName?cap_first}Service {
@@ -14,20 +17,19 @@ export class ${variables.etoName?cap_first}Service {
     size: number,
     page: number,
     searchTerms: any,
-    sort: any[],
+    sort: Sort[],
   ): Observable<any> {
-    const pageData: PageData = {
-      pagination: {
-        size: size,
-        page: page,
-        total: 1,
+    const searchCriteria: SearchCriteria = {
+      pageable: {
+        pageSize: size,
+        pageNumber: page,
+        sort: sort,
       },
     <#list pojo.fields as field>
       ${field.name}: searchTerms.${field.name},
     </#list>
-      sort: sort,
     };
-    return this.http.post<any>(this.urlService + 'search', pageData);
+    return this.http.post<any>(this.urlService + 'search', searchCriteria);
   }
 
   save${variables.etoName?cap_first}(data: any): Observable<Object> {

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/src/assets/i18n/en.json.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/src/assets/i18n/en.json.ftl
@@ -11,7 +11,7 @@
     "deleteItem": "Delete item"
   },
   "header": {
-    "title": "OASP4JS",
+    "title": "devon4ng",
     "error": "LOGIN ERROR",
     "EN": "English",
     "ES": "Spanish"

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/src/assets/i18n/es.json.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_angular_client_app/templates/src/assets/i18n/es.json.ftl
@@ -11,7 +11,7 @@
     "deleteItem": "Eliminar fila"
   },
   "header": {
-    "title": "OASP4JS",
+    "title": "devon4ng",
     "error": "Error de acceso",
     "EN": "Inglés",
     "ES": "Español"

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_java_server_app/templates/java/${variables.rootPackage}/${variables.component}/dataaccess/api/repo/${variables.entityName}Repository.java.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_java_server_app/templates/java/${variables.rootPackage}/${variables.component}/dataaccess/api/repo/${variables.entityName}Repository.java.ftl
@@ -70,7 +70,7 @@ public interface ${variables.entityName}Repository extends DefaultRepository<${v
     </#list>
     addOrderBy(query, alias, criteria.getPageable().getSort());
     
-    return QueryUtil.get().findPaginated(criteria.getPageable(), query, false);
+    return QueryUtil.get().findPaginated(criteria.getPageable(), query, true);
   }
   
   /**

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_java_server_app/templates/java/${variables.rootPackage}/general/logic/base/AbstractGenericEntityUtils.java.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_java_server_app/templates/java/${variables.rootPackage}/general/logic/base/AbstractGenericEntityUtils.java.ftl
@@ -21,8 +21,7 @@ import org.springframework.data.domain.Page;
 public class AbstractGenericEntityUtils extends AbstractBeanMapperSupport {
   /**
    * 
-   * The limit for {@link net.sf.mmm.util.search.base.AbstractSearchCriteria#getMaximumHitCount() maximum hit count} for
-   * UI requests.
+   * The limit for maximum hit count for UI requests.
    */
   protected static final int MAXIMUM_HIT_LIMIT = 500;
 
@@ -38,9 +37,11 @@ public class AbstractGenericEntityUtils extends AbstractBeanMapperSupport {
    */
   protected <T extends TransferObject, E extends PersistenceEntity<?>> Page<T> mapPaginatedEntityList(
       Page<E> paginatedList, Class<T> klass) {
+      
+    long totalElements = paginatedList.getTotalElements();  
 
     List<T> etoList = getBeanMapper().mapList(paginatedList.getContent(), klass);
-    Page<T> result = new PageImpl<T>(etoList, paginatedList.getPageable(), MAXIMUM_HIT_LIMIT);
+    Page<T> result = new PageImpl<T>(etoList, paginatedList.getPageable(), totalElements);
 
     return result;
   }

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_openapi_angular_client_app/templates/cobigen.properties
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_openapi_angular_client_app/templates/cobigen.properties
@@ -1,1 +1,1 @@
-relocate:../../oasp4js-application-template/${cwd}
+relocate:../../devon4ng-application-template/${cwd}

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_openapi_angular_client_app/templates/src/app/${variables.etoName#lower_case}/${variables.etoName#lower_case}-grid/${variables.etoName#lower_case}-grid.component.html.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_openapi_angular_client_app/templates/src/app/${variables.etoName#lower_case}/${variables.etoName#lower_case}-grid/${variables.etoName#lower_case}-grid.component.html.ftl
@@ -15,7 +15,7 @@
         <mat-icon>delete</mat-icon>
       </button>
 
-      <form (ngSubmit)="get${variables.etoName?cap_first}()" #filterForm="ngForm">
+      <form (ngSubmit)="filter()" #filterForm="ngForm">
         <td-expansion-panel label="Filters">
           <div layout="row" class="pad-left-md pad-right-md" style="align-items:center; border-bottom: 1px solid lightgrey" flex>
             <div layout-xs="column" class="justify-space-around" style="align-items:center" hide-gt-xs flex>

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_openapi_angular_client_app/templates/src/app/${variables.etoName#lower_case}/${variables.etoName#lower_case}-grid/${variables.etoName#lower_case}-grid.component.ts.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_openapi_angular_client_app/templates/src/app/${variables.etoName#lower_case}/${variables.etoName#lower_case}-grid/${variables.etoName#lower_case}-grid.component.ts.ftl
@@ -237,7 +237,6 @@ export class ${variables.etoName?cap_first}GridComponent implements OnInit {
   }
   
   filter(): void {
-    this.get${variables.etoName?cap_first}();
     this.pagingBar.firstPage();
   }
 

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_openapi_angular_client_app/templates/src/app/${variables.etoName#lower_case}/${variables.etoName#lower_case}-grid/${variables.etoName#lower_case}-grid.component.ts.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_openapi_angular_client_app/templates/src/app/${variables.etoName#lower_case}/${variables.etoName#lower_case}-grid/${variables.etoName#lower_case}-grid.component.ts.ftl
@@ -5,6 +5,7 @@ import {
   TdDialogService,
   IPageChangeEvent,
   ITdDataTableSortChangeEvent,
+  TdPagingBarComponent,
 } from '@covalent/core';
 import { MatDialogRef, MatDialog } from '@angular/material';
 import { Router } from '@angular/router';
@@ -13,7 +14,7 @@ import { ${variables.etoName?cap_first}Service } from '../services/${variables.e
 import { AuthService } from '../../core/security/auth.service';
 
 import { ${variables.etoName?cap_first}DialogComponent } from '../${variables.etoName?lower_case}-dialog/${variables.etoName?lower_case}-dialog.component';
-import { Pagination } from '../../core/interfaces/pagination';
+import { Pageable } from '../../core/interfaces/pageable';
 
 @Component({
   selector: 'public-${variables.etoName?lower_case}-grid',
@@ -21,11 +22,17 @@ import { Pagination } from '../../core/interfaces/pagination';
   styleUrls: ['./${variables.etoName?lower_case}-grid.component.scss'],
 })
 export class ${variables.etoName?cap_first}GridComponent implements OnInit {
-  private pagination: Pagination = {
-    size: 8,
-    page: 1,
-    total: 1,
-  };
+    @ViewChild('pagingBar')
+    pagingBar: TdPagingBarComponent;
+    
+    private pageable: Pageable = {
+        pageSize: 8,
+        pageNumber: 0,
+        sort: [{
+            property: '${model.properties[0].name!}',
+            direction: 'ASC'
+        }]
+    };
   private sorting: any[] = [];
 
   @ViewChild('dataTable') dataTable: TdDataTableComponent;
@@ -67,15 +74,15 @@ export class ${variables.etoName?cap_first}GridComponent implements OnInit {
   get${variables.etoName?cap_first}(): void {
     this.dataGridService
       .get${variables.etoName?cap_first}(
-        this.pageSize,
-        this.pagination.page,
+        this.pageable.pageSize,
+        this.pageable.pageNumber,
         this.searchTerms,
-        this.sorting,
+        this.pageable.sort = this.sorting,
       )
       .subscribe(
         (res: any) => {
-          this.data = res.result;
-          this.totalItems = res.pagination.total;
+          this.data = res.content;
+          this.totalItems = res.totalElements;
           this.dataTable.refresh();
         },
         (error: any) => {
@@ -111,10 +118,10 @@ export class ${variables.etoName?cap_first}GridComponent implements OnInit {
   }
 
   page(pagingEvent: IPageChangeEvent): void {
-    this.pagination = {
-      size: pagingEvent.pageSize,
-      page: pagingEvent.page,
-      total: 1,
+    this.pageable = {
+        pageSize: pagingEvent.pageSize,
+        pageNumber: pagingEvent.page - 1,
+        sort: this.pageable.sort,
     };
     this.get${variables.etoName?cap_first}();
   }
@@ -122,7 +129,7 @@ export class ${variables.etoName?cap_first}GridComponent implements OnInit {
   sort(sortEvent: ITdDataTableSortChangeEvent): void {
     this.sorting = [];
     this.sorting.push({
-     name: sortEvent.name.split('.').pop(),
+     property: sortEvent.name.split('.').pop(),
      direction: '' + sortEvent.order,
     });
     this.get${variables.etoName?cap_first}();
@@ -227,6 +234,11 @@ export class ${variables.etoName?cap_first}GridComponent implements OnInit {
           );
         }
       });
+  }
+  
+  filter(): void {
+    this.get${variables.etoName?cap_first}();
+    this.pagingBar.firstPage();
   }
 
   searchReset(form: any): void {

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_openapi_angular_client_app/templates/src/app/${variables.etoName#lower_case}/services/${variables.etoName#lower_case}.service.ts.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_openapi_angular_client_app/templates/src/app/${variables.etoName#lower_case}/services/${variables.etoName#lower_case}.service.ts.ftl
@@ -2,7 +2,10 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
 import { Observable } from 'rxjs';
-import { PageData } from '../../core/interfaces/page-data';
+import { SearchCriteria } from '../../core/interfaces/search-criteria';
+import { Sort } from '../../core/interfaces/sort';
+import { Pageable } from '../../core/interfaces/pageable';
+
 
 @Injectable()
 export class ${variables.etoName?cap_first}Service {
@@ -14,25 +17,25 @@ export class ${variables.etoName?cap_first}Service {
     size: number,
     page: number,
     searchTerms: any,
-    sort: any[],
+    sort: Sort[],
   ): Observable<any> {
-    const pageData: PageData = {
-      pagination: {
-        size: size,
-        page: page,
-        total: 1,
+    const searchCriteria: SearchCriteria = {
+      pageable: {
+        pageSize: size,
+        pageNumber: page,
+        sort: sort,
       },
     <#list model.properties as property>
       ${property.name}: searchTerms.${property.name},
     </#list>
-      sort: sort,
     };
-    return this.http.post<any>(this.urlService + 'search', pageData);
+    return this.http.post<any>(this.urlService + 'search', searchCriteria);
   }
 
   save${variables.etoName?cap_first}(data: any): Observable<Object> {
     const obj: any = {
       id: data.id,
+      modificationCounter: data.modificationCounter,
     <#list model.properties as property>
       ${property.name}: data.${property.name},
     </#list>

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_openapi_angular_client_app/templates/src/assets/i18n/en.json.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_openapi_angular_client_app/templates/src/assets/i18n/en.json.ftl
@@ -11,7 +11,7 @@
     "deleteItem": "Delete item"
   },
   "header": {
-    "title": "OASP4JS",
+    "title": "devon4ng",
     "error": "LOGIN ERROR",
     "EN": "English",
     "ES": "Spanish"

--- a/cobigen-templates/templates-oasp4j/src/main/templates/crud_openapi_angular_client_app/templates/src/assets/i18n/es.json.ftl
+++ b/cobigen-templates/templates-oasp4j/src/main/templates/crud_openapi_angular_client_app/templates/src/assets/i18n/es.json.ftl
@@ -11,7 +11,7 @@
     "deleteItem": "Eliminar fila"
   },
   "header": {
-    "title": "OASP4JS",
+    "title": "devon4ng",
     "error": "Error de acceso",
     "EN": "Inglés",
     "ES": "Español"


### PR DESCRIPTION
Changing Angular templates to fit the new devon4j/oasp4j 3.0.0 version.

Implements

* Added pageable, searchCriteria and sort interfaces.
* Fixed issue on the server side when doing pagination.
* Fixed a bug when sorting.
* Fixed a bug when searching for elements.
* Renamed the Angular application template to `devon4ng`.

@devonfw/cobigen
