### PR TITLE
Built jar of templates-oasp4j is incorrect

### DIFF
--- a/cobigen-templates/pom.xml
+++ b/cobigen-templates/pom.xml
@@ -31,6 +31,7 @@
     <resources>
       <resource>
         <directory>src/main/templates</directory>
+		<targetPath>src/main/templates</targetPath>
       </resource>
     </resources>
     <plugins>

--- a/cobigen-templates/pom.xml
+++ b/cobigen-templates/pom.xml
@@ -31,7 +31,7 @@
     <resources>
       <resource>
         <directory>src/main/templates</directory>
-		<targetPath>src/main/templates</targetPath>
+        <targetPath>src/main/templates</targetPath>
       </resource>
     </resources>
     <plugins>


### PR DESCRIPTION
Adresses #778 .

Changed the pom so that when the jar is created, the templates folder are correctly stored on `src/main/templates` instead of the root folder.

@devonfw/cobigen
