### PR TITLE
Refreshing relative project

### DIFF
--- a/cobigen-eclipse/cobigen-eclipse/plugin.xml
+++ b/cobigen-eclipse/cobigen-eclipse/plugin.xml
@@ -11,6 +11,14 @@
             id="com.devonfw.cobigen.eclipseplugin.healthy_check"
             name="Healthy Check">
       </command>
+      <command
+            id="com.devonfw.cobigen.eclipseplugin.update_template"
+            name="Update Template">
+      </command>
+      <command
+            id="com.devonfw.cobigen.eclipseplugin.adapt_template"
+            name="Adapt Template">
+      </command>
    </extension>
    <extension
          point="org.eclipse.ui.handlers">
@@ -21,6 +29,14 @@
       <handler
             class="com.devonfw.cobigen.eclipse.workbenchcontrol.handler.HealthCheckHandler"
             commandId="com.devonfw.cobigen.eclipseplugin.health_check">
+      </handler>
+       <handler
+            class="com.devonfw.cobigen.eclipse.workbenchcontrol.handler.UpdateTemplatesHandler"
+            commandId="com.devonfw.cobigen.eclipseplugin.update_template">
+      </handler>
+      <handler
+            class="com.devonfw.cobigen.eclipse.workbenchcontrol.handler.AdaptTemplatesHandler"
+            commandId="com.devonfw.cobigen.eclipseplugin.adapt_template">
       </handler>
    </extension>
    <extension
@@ -42,6 +58,16 @@
              <command
                    commandId="com.devonfw.cobigen.eclipseplugin.health_check"
                    label="Health Check..."
+                   style="push">
+             </command>
+             <command
+                   commandId="com.devonfw.cobigen.eclipseplugin.update_template"
+                   label="Update Templates..."
+                   style="push">
+             </command>
+             <command
+                   commandId="com.devonfw.cobigen.eclipseplugin.adapt_template"
+                   label="Adapt Templates..."
                    style="push">
              </command>
           </menu>
@@ -69,6 +95,16 @@
                    label="Health Check..."
                    style="push">
              </command>
+             <command
+                   commandId="com.devonfw.cobigen.eclipseplugin.update_template"
+                   label="Update Templates..."
+                   style="push">
+             </command>
+             <command
+                   commandId="com.devonfw.cobigen.eclipseplugin.adapt_template"
+                   label="Adapt Templates..."
+                   style="push">
+             </command>
           </menu>
           <separator
                 name="com.devonfw.cobigen.eclipseplugin.separator4"
@@ -92,6 +128,16 @@
              <command
                    commandId="com.devonfw.cobigen.eclipseplugin.health_check"
                    label="Health Check..."
+                   style="push">
+             </command>
+             <command
+                   commandId="com.devonfw.cobigen.eclipseplugin.update_template"
+                   label="Update Templates..."
+                   style="push">
+             </command>
+             <command
+                   commandId="com.devonfw.cobigen.eclipseplugin.adapt_template"
+                   label="Adapt Templates..."
                    style="push">
              </command>
              <visibleWhen

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/constants/external/CobiGenDialogConstants.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/constants/external/CobiGenDialogConstants.java
@@ -33,4 +33,12 @@ public class CobiGenDialogConstants {
         /** Dialog title of the generate wizard for batch processing */
         public static final String DIALOG_TITLE_BATCH = "CobiGen (batch mode)";
     }
+
+    /** Dialog constants of the Update Templates */
+    public class UpdateTemplateDialogs {
+
+        /** Dialog title of the Update Templates */
+        public static final String DIALOG_TITLE = "Update Cobigen Templates";
+
+    }
 }

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/constants/external/ResourceConstants.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/constants/external/ResourceConstants.java
@@ -5,8 +5,14 @@ package com.devonfw.cobigen.eclipse.common.constants.external;
  */
 public class ResourceConstants {
 
-    /**
-     * Generator Configuration Project Name
-     */
-    public static final String CONFIG_PROJECT_NAME = "CobiGen_Templates";
+	/**
+	 * Generator Configuration Project Name
+	 */
+	public static final String CONFIG_PROJECT_NAME = "CobiGen_Templates";
+
+	/**
+	 * Latest Jar folder downloaded from Update Templates
+	 */
+	public static final String DOWNLOADED_JAR_FOLDER = "/.metadata/cobigen_jars";
+
 }

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/tools/PathUtil.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/tools/PathUtil.java
@@ -1,6 +1,5 @@
 package com.devonfw.cobigen.eclipse.common.tools;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
@@ -8,7 +7,6 @@ import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.ResourcesPlugin;
 
 /**
  * The {@link PathUtil} class provides some common functionality on workspace relative paths
@@ -93,31 +91,4 @@ public class PathUtil {
         return "/" + proj.getName() + "/" + relativeDestinationPath;
     }
 
-    /**
-     * Tries to return the relative project of a template. This is useful when a template is going to be
-     * relocated to a different project from the original one (the one were the input is located). Therefore
-     * the path is relative (i.e. projectname-core/../api/src/main...) and we need to get that relative
-     * project (i.e. projectname-api)
-     *
-     * @param filePath
-     *            the path of the template that maybe needs to be relocated
-     * @param project
-     *            the project containing the class used as input
-     * @return the same project if no relative path was found, and the relative project if a relative path has
-     *         been found
-     */
-    public static IProject getRelativeProjectIfNeeded(String filePath, IProject project) {
-        if (filePath.contains("/../")) {
-            String projectPath = project.getLocation().toFile().getParent().toString();
-            String projectName = projectPath.substring(projectPath.lastIndexOf(File.separator));
-
-            // We want to get the project name after "/../" which is the child project
-            int nextChildProject = filePath.indexOf("/../") + 4;
-            filePath = filePath.substring(nextChildProject, filePath.length());
-            filePath = projectName + "-" + filePath;
-
-            return ResourcesPlugin.getWorkspace().getRoot().getProject(PathUtil.getProject(filePath));
-        }
-        return project;
-    }
 }

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/tools/PathUtil.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/tools/PathUtil.java
@@ -1,5 +1,6 @@
 package com.devonfw.cobigen.eclipse.common.tools;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
@@ -7,6 +8,7 @@ import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
 
 /**
  * The {@link PathUtil} class provides some common functionality on workspace relative paths
@@ -89,5 +91,33 @@ public class PathUtil {
      */
     public static String createWorkspaceRelativePath(IProject proj, String relativeDestinationPath) {
         return "/" + proj.getName() + "/" + relativeDestinationPath;
+    }
+
+    /**
+     * Tries to return the relative project of a template. This is useful when a template is going to be
+     * relocated to a different project from the original one (the one were the input is located). Therefore
+     * the path is relative (i.e. projectname-core/../api/src/main...) and we need to get that relative
+     * project (i.e. projectname-api)
+     *
+     * @param filePath
+     *            the path of the template that maybe needs to be relocated
+     * @param project
+     *            the project containing the class used as input
+     * @return the same project if no relative path was found, and the relative project if a relative path has
+     *         been found
+     */
+    public static IProject getRelativeProjectIfNeeded(String filePath, IProject project) {
+        if (filePath.contains("/../")) {
+            String projectPath = project.getLocation().toFile().getParent().toString();
+            String projectName = projectPath.substring(projectPath.lastIndexOf(File.separator));
+
+            // We want to get the project name after "/../" which is the child project
+            int nextChildProject = filePath.indexOf("/../") + 4;
+            filePath = filePath.substring(nextChildProject, filePath.length());
+            filePath = projectName + "-" + filePath;
+
+            return ResourcesPlugin.getWorkspace().getRoot().getProject(PathUtil.getProject(filePath));
+        }
+        return project;
     }
 }

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/tools/ResourcesPluginUtil.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/tools/ResourcesPluginUtil.java
@@ -1,9 +1,20 @@
 package com.devonfw.cobigen.eclipse.common.tools;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.widgets.Display;
@@ -20,11 +31,27 @@ public class ResourcesPluginUtil {
     private static final Logger LOG = LoggerFactory.getLogger(ResourcesPluginUtil.class);
 
     /**
+     * Generator project
+     */
+    static IProject generatorProj;
+
+    /**
+     * If Update Dialog already shown while refreshConfigurationProject, don't show it again in call of
+     * getGeneratorConfigurationProject
+     */
+    static boolean isUpdateDialogShown = true;    
+
+    /**
      * Refreshes the configuration project from the file system.
      */
+   
     public static void refreshConfigurationProject() {
         try {
-            getGeneratorConfigurationProject().refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
+           // isUpdateDialogShown = true;
+            generatorProj = getGeneratorConfigurationProject();
+            if (null != generatorProj && !generatorProj.exists()) {
+                generatorProj.refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
+            }
         } catch (CoreException e) {
             MessageDialog.openWarning(Display.getDefault().getActiveShell(), "Warning",
                 "Could not refresh the CobiGen configuration project automatically. " + "Please try it again manually");
@@ -45,15 +72,76 @@ public class ResourcesPluginUtil {
     public static IProject getGeneratorConfigurationProject()
         throws GeneratorProjectNotExistentException, CoreException {
 
-        IProject generatorProj =
-            ResourcesPlugin.getWorkspace().getRoot().getProject(ResourceConstants.CONFIG_PROJECT_NAME);
+        generatorProj = ResourcesPlugin.getWorkspace().getRoot().getProject(ResourceConstants.CONFIG_PROJECT_NAME);       
         if (!generatorProj.exists()) {
-            throw new GeneratorProjectNotExistentException();
+        	          
+                MessageDialog dialog = new MessageDialog(Display.getDefault().getActiveShell(),
+                    "Generator configuration project not found!", null,
+                    "Cobigen_templates folder is not imported. Do you want to download latest templates and use it", 0,
+                    new String[] { "Update", "Cancel" }, 1);
+                dialog.setBlockOnOpen(true);
+                dialog.open();
+              
+            /*if (result == 0) {
+                //isUpdateDialogShown = false;
+                return null;
+
+            } else {
+                MessageDialog.openError(Display.getDefault().getActiveShell(),
+                    "Generator configuration project not found!",
+                    "The project '" + ResourceConstants.CONFIG_PROJECT_NAME
+                        + "' containing the configuration and templates is currently not existent. Please create one or check it out from SVN as stated in the user documentation.");
+
+                throw new GeneratorProjectNotExistentException();
+            }*/
         }
-        if (!generatorProj.isOpen()) {
+        /*if (generatorProj.isOpen()) {
             generatorProj.open(new NullProgressMonitor());
-        }
+        }*/
 
         return generatorProj;
+    }
+
+    /**
+     * @param isDownloadSource
+     *            true if downloading source jar file
+     * @return fileName Name of the file downloaded
+     * @throws MalformedURLException
+     *             {@link MalformedURLException} occurred
+     * @throws IOException
+     *             {@link IOException} occurred
+     */
+    public static String downloadJar(boolean isDownloadSource) throws MalformedURLException, IOException {
+       String mavenUrl =
+            "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.devonfw.cobigen&a=templates-oasp4j&v=LATEST";
+        if (isDownloadSource) {
+            mavenUrl = mavenUrl + "&c=sources";
+        }
+        File directory = new File(ResourcesPlugin.getWorkspace().getRoot().getLocation().toPortableString()
+            + ResourceConstants.DOWNLOADED_JAR_FOLDER);
+        if (!directory.exists()) {
+            directory.mkdir();
+        }
+       URL url = new URL(mavenUrl);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.connect();
+        InputStream inputStream = conn.getInputStream();
+        String fileName = conn.getURL().getFile().substring(conn.getURL().getFile().lastIndexOf("/") + 1);
+        File file = new File(directory.getPath() + File.separator + fileName);
+        Path targetPath = file.toPath();
+        if (!file.exists()) {
+            Files.copy(inputStream, targetPath, StandardCopyOption.REPLACE_EXISTING);
+        }
+        conn.disconnect();    	
+        return fileName;
+    }
+
+    /**
+     * @return workspace location
+     */
+    public static IPath getWorkspaceLocation() {
+        IPath ws = ResourcesPlugin.getWorkspace().getRoot().getLocation();
+        return ws;
     }
 }

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/generator/GeneratorWrapperFactory.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/generator/GeneratorWrapperFactory.java
@@ -1,5 +1,6 @@
 package com.devonfw.cobigen.eclipse.generator;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -7,6 +8,7 @@ import java.util.List;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IPackageFragment;
@@ -22,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import com.devonfw.cobigen.api.CobiGen;
 import com.devonfw.cobigen.api.exception.InvalidConfigurationException;
+import com.devonfw.cobigen.eclipse.common.constants.external.ResourceConstants;
 import com.devonfw.cobigen.eclipse.common.exceptions.GeneratorCreationException;
 import com.devonfw.cobigen.eclipse.common.exceptions.GeneratorProjectNotExistentException;
 import com.devonfw.cobigen.eclipse.common.exceptions.InvalidInputException;
@@ -206,13 +209,19 @@ public class GeneratorWrapperFactory {
      * @throws GeneratorCreationException
      *             if the generator configuration project does not exist
      */
-    private static CobiGen initializeGenerator()
-        throws GeneratorProjectNotExistentException, InvalidConfigurationException, GeneratorCreationException {
+    private static CobiGen initializeGenerator() throws InvalidConfigurationException, GeneratorCreationException {
 
         try {
             ResourcesPluginUtil.refreshConfigurationProject();
             IProject generatorProj = ResourcesPluginUtil.getGeneratorConfigurationProject();
-            return CobiGenFactory.create(generatorProj.getLocationURI());
+            if (null == generatorProj.getLocationURI()) {
+                String fileName = ResourcesPluginUtil.downloadJar(false);
+                IPath ws = ResourcesPluginUtil.getWorkspaceLocation();
+                File file = new File(ws.append(ResourceConstants.DOWNLOADED_JAR_FOLDER + File.separator + fileName).toString());
+                return CobiGenFactory.create(file.toURI());
+            } else {
+                return CobiGenFactory.create(generatorProj.getLocationURI());
+            }
         } catch (CoreException e) {
             throw new GeneratorCreationException("An eclipse internal exception occurred", e);
         } catch (IOException e) {

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/healthcheck/HealthCheckDialog.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/healthcheck/HealthCheckDialog.java
@@ -1,9 +1,11 @@
 package com.devonfw.cobigen.eclipse.healthcheck;
 
 import java.io.File;
+import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -69,15 +71,18 @@ public class HealthCheckDialog {
 
             // refresh and check context configuration
             ResourcesPluginUtil.refreshConfigurationProject();
-            CobiGenFactory.create(generatorConfProj.getLocationURI());
-
+			if (generatorConfProj.getLocationURI() != null) {
+				CobiGenFactory.create(generatorConfProj.getLocationURI());
+			}
             healthyCheckMessage = firstStep + "OK.";
             healthyCheckMessage += secondStep;
             boolean healthyCheckWarning = false;
-            if (new File(Paths.get(generatorConfProj.getLocationURI()).toString(),
-                ConfigurationConstants.CONTEXT_CONFIG_FILENAME).exists()) {
-                healthyCheckMessage += "OK.";
-            } else {
+			if (generatorConfProj.getLocationURI() != null) {
+				if (new File(Paths.get(generatorConfProj.getLocationURI()).toString(),
+						ConfigurationConstants.CONTEXT_CONFIG_FILENAME).exists()) {
+					healthyCheckMessage += "OK.";
+				}
+			} else {
                 healthyCheckMessage += "INVALID.";
                 healthyCheckWarning = true;
             }

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/updatetemplates/UpdateTemplatesDialog.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/updatetemplates/UpdateTemplatesDialog.java
@@ -1,0 +1,132 @@
+package com.devonfw.cobigen.eclipse.updatetemplates;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.UUID;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.apache.commons.logging.Log;
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import com.devonfw.cobigen.api.exception.CobiGenRuntimeException;
+import com.devonfw.cobigen.eclipse.common.constants.InfrastructureConstants;
+import com.devonfw.cobigen.eclipse.common.constants.external.CobiGenDialogConstants.UpdateTemplateDialogs;
+import com.devonfw.cobigen.eclipse.common.tools.ResourcesPluginUtil;
+
+/**
+ * Dialog to update templates from Maven central
+ */
+public class UpdateTemplatesDialog extends Dialog {
+
+    /** Logger instance. */
+    private static final Logger LOG = LoggerFactory.getLogger(UpdateTemplatesDialog.class);
+
+    /**
+     * Creates a new {@link UpdateTemplatesDialog}
+     */
+    public UpdateTemplatesDialog() {
+        super(Display.getDefault().getActiveShell());
+
+        // Create a new trust manager that trust all certificates
+        TrustManager[] trustAllCerts = new TrustManager[] { new X509TrustManager() {
+            @Override
+            public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                return null;
+            }
+
+            @Override
+            public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType) {
+            }
+
+            @Override
+            public void checkServerTrusted(java.security.cert.X509Certificate[] certs, String authType) {
+            }
+        } };
+
+        // Activate the new trust manager
+        try {
+            SSLContext sc = SSLContext.getInstance("SSL");
+            sc.init(null, trustAllCerts, new java.security.SecureRandom());
+            HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+        } catch (Exception e) {
+        	throw new Error("Failed to initialize SSLcontex",e);
+        }
+
+    }
+
+    @Override
+    protected Control createDialogArea(Composite parent) {
+        MDC.put(InfrastructureConstants.CORRELATION_ID, UUID.randomUUID().toString());
+
+        getShell().setText(UpdateTemplateDialogs.DIALOG_TITLE);
+        Composite contentParent = new Composite(parent, SWT.NONE);
+        GridData gridData = new GridData(GridData.FILL, GridData.FILL, true, true);
+        contentParent.setLayoutData(gridData);
+
+        GridLayout layout = new GridLayout(2, false);
+        layout.marginWidth = 15;
+        layout.marginHeight = 15;
+        contentParent.setLayout(layout);
+
+        Label introduction = new Label(contentParent, SWT.LEFT);
+        gridData = new GridData(GridData.FILL, GridData.FILL, true, true);
+        gridData.widthHint = 450;
+        gridData.horizontalSpan = 2;
+        introduction.setText("The following template folders will be downloaded from maven central repository:");
+        introduction.setLayoutData(gridData);
+
+        GridData leftGridData = new GridData(GridData.BEGINNING, GridData.CENTER, true, false);
+        leftGridData.widthHint = 320;
+        GridData rightGridData = new GridData(GridData.CENTER, GridData.CENTER, false, false);
+        rightGridData.widthHint = 80;
+        Label label = new Label(contentParent, SWT.NONE);
+        label.setText("templates-oasp4j");
+        label.setLayoutData(leftGridData);
+        MDC.remove(InfrastructureConstants.CORRELATION_ID);
+        return contentParent;
+    }
+
+    @Override
+    protected void createButtonsForButtonBar(Composite parent) {
+
+        Button button = createButton(parent, IDialogConstants.OK_ID, "Download", false);
+        button.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                try {
+                    ResourcesPluginUtil.downloadJar(false);
+                    MessageDialog dialog = new MessageDialog(Display.getDefault().getActiveShell(), "Information!!",
+                        null, "Downloaded succesfully", MessageDialog.INFORMATION, new String[] { "Ok" }, 1);
+                    dialog.setBlockOnOpen(true);
+                    dialog.open();
+                } catch (MalformedURLException e1) {
+                    throw new CobiGenRuntimeException("Invalid maven centrol repo url or path doesn't exist " + e1);
+                } catch (IOException e1) {
+                    throw new CobiGenRuntimeException("Failed while reading or writing Jar at .metadata folder" + e1);
+                }
+            }
+        });
+
+        createButton(parent, IDialogConstants.CANCEL_ID, IDialogConstants.CANCEL_LABEL, true);
+    }
+
+}

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/wizard/common/model/HierarchicalTreeOperator.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/wizard/common/model/HierarchicalTreeOperator.java
@@ -299,7 +299,7 @@ public class HierarchicalTreeOperator {
             }
             return fullChildName;
         }
-        return "INVALID";
+        return "INVALID2";
     }
 
     /**

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/wizard/generate/control/GenerateSelectionJob.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/wizard/generate/control/GenerateSelectionJob.java
@@ -84,8 +84,11 @@ public class GenerateSelectionJob extends AbstractCobiGenJob {
                     cobigenWrapper.getWorkspaceDependentTemplateDestinationPath(generationReport.getGeneratedFiles());
                 Set<IProject> projects = Sets.newHashSet();
                 for (String filePath : generatedFiles) {
+
                     IProject project =
                         ResourcesPlugin.getWorkspace().getRoot().getProject(PathUtil.getProject(filePath));
+                    project = PathUtil.getRelativeProjectIfNeeded(filePath, project);
+
                     if (project.exists()) {
                         projects.add(project);
                     }

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/wizard/generate/control/GenerateSelectionJob.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/wizard/generate/control/GenerateSelectionJob.java
@@ -87,7 +87,6 @@ public class GenerateSelectionJob extends AbstractCobiGenJob {
 
                     IProject project =
                         ResourcesPlugin.getWorkspace().getRoot().getProject(PathUtil.getProject(filePath));
-                    project = PathUtil.getRelativeProjectIfNeeded(filePath, project);
 
                     if (project.exists()) {
                         projects.add(project);

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/workbenchcontrol/handler/AdaptTemplatesHandler.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/workbenchcontrol/handler/AdaptTemplatesHandler.java
@@ -1,0 +1,213 @@
+package com.devonfw.cobigen.eclipse.workbenchcontrol.handler;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import com.devonfw.cobigen.impl.config.entity.Trigger;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.widgets.Display;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import com.devonfw.cobigen.eclipse.common.constants.InfrastructureConstants;
+import com.devonfw.cobigen.eclipse.common.constants.external.ResourceConstants;
+import com.devonfw.cobigen.eclipse.common.exceptions.GeneratorProjectNotExistentException;
+import com.devonfw.cobigen.eclipse.common.tools.PlatformUIUtil;
+import com.devonfw.cobigen.eclipse.common.tools.ResourcesPluginUtil;
+import com.devonfw.cobigen.impl.config.ContextConfiguration;
+
+/**
+ * Handler for the Package-Explorer EventfimportProjectIntoWorkspace
+ */
+public class AdaptTemplatesHandler extends AbstractHandler {
+
+    /**
+     * Assigning logger to UpdateTemplatesHandler
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(AdaptTemplatesHandler.class);
+
+    /**
+     * Location of workspace root
+     */
+    IPath ws = ResourcesPluginUtil.getWorkspaceLocation();
+   
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+
+        MDC.put(InfrastructureConstants.CORRELATION_ID, UUID.randomUUID().toString());
+        IProject generatorProj =
+            ResourcesPlugin.getWorkspace().getRoot().getProject(ResourceConstants.CONFIG_PROJECT_NAME);
+
+        if (generatorProj.exists()) {
+            MessageDialog dialog = new MessageDialog(Display.getDefault().getActiveShell(), "Info!", null,
+                "Cobigen_Templates folder is already imported, click on Update templates button to update with latest. ",
+                MessageDialog.INFORMATION, new String[] { "Ok" }, 1);
+            dialog.setBlockOnOpen(true);
+            dialog.open();
+        } else {
+            MessageDialog dialog = new MessageDialog(Display.getDefault().getActiveShell(), "Warning!", null,
+                "Clicking on ok button will override existing Cobigen_templates in workspace.", MessageDialog.WARNING,
+                new String[] { "Ok", "Cancel" }, 1);
+            dialog.setBlockOnOpen(true);
+            int result = dialog.open();
+
+            if (result == 0) {
+                try {
+                    String fileName = ResourcesPluginUtil.downloadJar(true);               
+                    processJar(fileName);
+                    importProjectIntoWorkspace();
+                    dialog = new MessageDialog(Display.getDefault().getActiveShell(), "Information", null,
+                        "Cobigen_Templates folder is imported sucessfully", MessageDialog.INFORMATION,
+                        new String[] { "Ok" }, 1);
+                    dialog.setBlockOnOpen(true);
+                    dialog.open();
+                }
+                catch (MalformedURLException e) {
+                    LOG.error("An exception with download url of maven central", e);
+                    PlatformUIUtil.openErrorDialog("An exception with download url of maven central", e);
+                } catch (IOException e) {
+                    LOG.error("An exception occurred while writing Jar files to .metadata folder", e);
+                    PlatformUIUtil.openErrorDialog("An exception occurred while writing Jar files to .metadata folder",
+                        e);
+                }
+            }
+            MDC.remove(InfrastructureConstants.CORRELATION_ID);
+        }
+        return null;
+
+    }
+
+    /**
+     * Cobigen_Templates folder created at main folder using source jar will be imported into workspace
+     */
+    private void importProjectIntoWorkspace() {
+
+        try {
+            IProject project =
+                ResourcesPlugin.getWorkspace().getRoot().getProject(ResourceConstants.CONFIG_PROJECT_NAME);
+            IProjectDescription description = ResourcesPlugin.getWorkspace().newProjectDescription(project.getName());
+            description.setLocation(
+                new org.eclipse.core.runtime.Path(ws.toPortableString() + "/CobiGen_Templates"));
+            project.create(description, null);
+            project.open(null);
+		} catch (CoreException e) {
+			e.printStackTrace();
+		MessageDialog.openWarning(Display.getDefault().getActiveShell(), "Warning",
+					"Some Exception occurred while importing Cobigen_Templates into workspace");
+			// LOG.warn("Some Exception occurred while importing Cobigen_Templates into
+			// workspace", e);
+		}
+    }
+
+    /**
+     * Process Jar method is responsible for unzip the source Jar and create new Cobigen_templates folder
+     * structure at /main/CobiGen_Templates location
+     * @param fileName
+     *            Name of source jar file downloaded
+     */
+    private void processJar(String fileName) {       
+        String pathForCobigenTemplates = "";
+		try {
+			pathForCobigenTemplates = ws.toPortableString() + (((ResourcesPluginUtil.getGeneratorConfigurationProject() != null) && (ResourcesPluginUtil.getGeneratorConfigurationProject().getLocation() != null) ) ? ResourcesPluginUtil.getGeneratorConfigurationProject().getLocation() : StringUtils.EMPTY);
+		} catch (GeneratorProjectNotExistentException e1) {
+			// TODO Auto-generated catch block
+			e1.printStackTrace();
+		} catch (CoreException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		 String jarPath = ws.toPortableString() + ResourceConstants.DOWNLOADED_JAR_FOLDER + "/" + fileName;
+        FileSystem fileSystem = FileSystems.getDefault();
+        Path cobigenFolderPath=null;
+        if(fileSystem !=null && fileSystem.getPath(pathForCobigenTemplates) != null)
+        {
+         cobigenFolderPath = fileSystem.getPath(pathForCobigenTemplates);
+        }
+       /* Path configFolder = fileSystem.getPath(ws.toPortableString());
+        ContextConfiguration contextConfiguration = new ContextConfiguration(configFolder);
+        List<String> templateNames = new ArrayList<>();
+        for (com.devonfw.cobigen.impl.config.entity.Trigger t : contextConfiguration.getTriggers()) {
+            templateNames.add(t.getTemplateFolder());
+        }*/
+        List<String> templateNames = new ArrayList<>();
+        try (ZipFile file = new ZipFile(jarPath)) {
+            //deleteDirectoryStream(configFolder);
+            Enumeration<? extends ZipEntry> entries = file.entries();
+            if (Files.notExists(cobigenFolderPath)) {
+                Files.createDirectory(cobigenFolderPath);
+            }              
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                Path saveForFileCreationPath = fileSystem.getPath(cobigenFolderPath + File.separator + "CobiGen_Templates"
+                        + File.separator + File.separator + entry.getName());
+                if (templateNames.parallelStream().anyMatch(entry.getName()::contains)
+                    || entry.getName().contains("context.xml")) {
+                    saveForFileCreationPath = fileSystem.getPath(cobigenFolderPath + File.separator + "CobiGen_Templates"
+                            + File.separator  /*+ "src"
+                        + File.separator + "main" + File.separator + "templates"*/ + File.separator + entry.getName());
+                } else if (entry.getName().contains("com/")) {
+                    saveForFileCreationPath = fileSystem.getPath(cobigenFolderPath + File.separator + "CobiGen_Templates"
+                             + File.separator + "src"
+                        + File.separator + "main" + File.separator + "java" + File.separator + entry.getName());
+                }
+                if (entry.isDirectory()) {
+                    Files.createDirectories(saveForFileCreationPath);
+                } else {
+                    Files.deleteIfExists(saveForFileCreationPath);
+                    try (InputStream is = file.getInputStream(entry);
+                        BufferedInputStream bis = new BufferedInputStream(is);) {
+                        Files.createFile(saveForFileCreationPath);
+                        FileOutputStream fileOutput = new FileOutputStream(saveForFileCreationPath.toString());
+                        while (bis.available() > 0) {
+                            fileOutput.write(bis.read());
+                        }
+                        fileOutput.close();
+                    }
+                }
+            }
+		} catch (IOException e) {
+
+			 LOG.error("An exception occurred while processing Jar files to create Cobigen_Templates folder", e);
+			// PlatformUIUtil.openErrorDialog("An exception occurred while processing Jar
+			// file", e);
+		}
+    }
+
+    /**
+     * This method is responsible for deleting existing templates
+     *
+     * @param path
+     *            path of Cobigen_Templates to be overridden
+     * @throws IOException
+     *             exception will be thrown in case path doesn't exist
+     */
+    void deleteDirectoryStream(Path path) throws IOException {
+       // Files.walk(path).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+    }
+}

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/workbenchcontrol/handler/UpdateTemplatesHandler.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/workbenchcontrol/handler/UpdateTemplatesHandler.java
@@ -1,0 +1,42 @@
+package com.devonfw.cobigen.eclipse.workbenchcontrol.handler;
+
+import java.util.UUID;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import com.devonfw.cobigen.eclipse.common.constants.InfrastructureConstants;
+import com.devonfw.cobigen.eclipse.common.tools.PlatformUIUtil;
+import com.devonfw.cobigen.eclipse.updatetemplates.UpdateTemplatesDialog;
+
+/**
+ * Handler for the Package-Explorer Event
+ */
+public class UpdateTemplatesHandler extends AbstractHandler {
+
+    /**
+     * Assigning logger to UpdateTemplatesHandler
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(UpdateTemplatesHandler.class);
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+
+        MDC.put(InfrastructureConstants.CORRELATION_ID, UUID.randomUUID().toString());
+        try {
+            UpdateTemplatesDialog updateTemplatesDialog = new UpdateTemplatesDialog();
+            updateTemplatesDialog.open();
+        } catch (Throwable e) {
+            LOG.error("An unexpected error occurred while opening update dialog. This is a bug.", e);
+            PlatformUIUtil
+                .openErrorDialog("An unexpected error occurred while opening update dialog. This might be a bug.", e);
+        }
+
+        MDC.remove(InfrastructureConstants.CORRELATION_ID);
+        return null;
+    }
+}


### PR DESCRIPTION
This PR implements a way to refresh a relative project. It is useful when a template is going to be relocated to a different project from the original one (the one where the input is located). Therefore the path is relative (i.e. projectname-core/../api/src/main...) and we need to get that relative project (i.e. projectname-api).

It only does work in case of having a project on the system path like this:

projectname /
├── core /
│   ├── InputFile.java
├── api/
│   ├── template will be generated here
└── 

It is very hard to make this implementation generic for every project, as they may have different structures.

@devonfw/cobigen
