### PR TITLE
Fixing utils loading on jar

### DIFF
--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/constants/external/ResourceConstants.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/constants/external/ResourceConstants.java
@@ -21,4 +21,10 @@ public class ResourceConstants {
      */
     public static final String JAR_FILE_REGEX_NAME = "templates-([^-]+)-(\\d+\\.?)+.jar";
 
+    /**
+     * Source kar regular expression name to be used in a file name filter, so that we can check whether the
+     * templates are already downloaded. Checks "templates-anystring-anydigitbetweendots-sources.jar"
+     */
+    public static final String SOURCES_FILE_REGEX_NAME = "templates-([^-]+)-(\\d+\\.?)+-sources.jar";
+
 }

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/tools/ResourcesPluginUtil.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/tools/ResourcesPluginUtil.java
@@ -41,6 +41,11 @@ import com.devonfw.cobigen.eclipse.common.exceptions.GeneratorProjectNotExistent
 /** Util for NPE save access of {@link ResourcesPlugin} utils */
 public class ResourcesPluginUtil {
 
+    /**
+     *
+     */
+    private static final String COBIGEN_TEMPLATES = "CobiGen_Templates";
+
     /** Logger instance. */
     private static final Logger LOG = LoggerFactory.getLogger(ResourcesPluginUtil.class);
 
@@ -62,13 +67,36 @@ public class ResourcesPluginUtil {
     static boolean userWantsToDownloadTemplates = true;
 
     /**
-     * Filters the files on a directory so that we can check whether the templates are already downloaded
+     * Filters the files on a directory so that we can check whether the templates jar are already downloaded
      */
-    static FilenameFilter fileNameFilter = new FilenameFilter() {
+    static FilenameFilter fileNameFilterJar = new FilenameFilter() {
+        boolean isSource = false;
+
         @Override
         public boolean accept(File dir, String name) {
             String lowercaseName = name.toLowerCase();
             String regex = ResourceConstants.JAR_FILE_REGEX_NAME;
+
+            Pattern p = Pattern.compile(regex);
+            Matcher m = p.matcher(lowercaseName);
+            if (m.find()) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    };
+
+    /**
+     * Filters the files on a directory so that we can check whether the templates jar are already downloaded
+     */
+    static FilenameFilter fileNameFilterSources = new FilenameFilter() {
+        boolean isSource = false;
+
+        @Override
+        public boolean accept(File dir, String name) {
+            String lowercaseName = name.toLowerCase();
+            String regex = ResourceConstants.SOURCES_FILE_REGEX_NAME;
 
             Pattern p = Pattern.compile(regex);
             Matcher m = p.matcher(lowercaseName);
@@ -121,7 +149,7 @@ public class ResourcesPluginUtil {
                 if (templatesDirectory.exists()) {
 
                     // If we don't find at least one jar, then we do need to download new templates
-                    if (templatesDirectory.listFiles(fileNameFilter).length <= 0) {
+                    if (templatesDirectory.listFiles(fileNameFilterJar).length <= 0) {
                         int result = createUpdateTemplatesDialog();
                         isUpdateDialogShown = true;
                         if (result == 1) {
@@ -177,20 +205,22 @@ public class ResourcesPluginUtil {
      */
     public static String downloadJar(boolean isDownloadSource) throws MalformedURLException, IOException {
         String mavenUrl =
-            "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.devonfw.cobigen&a=templates-oasp4j&v=LATEST";
+            "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.devonfw.cobigen&a=templates-devon4j&v=LATEST";
         if (isDownloadSource) {
             mavenUrl = mavenUrl + "&c=sources";
         }
 
         String fileName = "";
 
-        File templatesDirectory = new File(ResourcesPlugin.getWorkspace().getRoot().getLocation().toPortableString()
-            + ResourceConstants.DOWNLOADED_JAR_FOLDER);
-        if (!templatesDirectory.exists()) {
-            templatesDirectory.mkdir();
-        }
+        File templatesDirectory = getTemplatesDirectory();
 
-        File[] jarFiles = templatesDirectory.listFiles(fileNameFilter);
+        File[] jarFiles;
+
+        if (isDownloadSource) {
+            jarFiles = templatesDirectory.listFiles(fileNameFilterSources);
+        } else {
+            jarFiles = templatesDirectory.listFiles(fileNameFilterJar);
+        }
 
         if (jarFiles.length <= 0) {
             ProgressMonitorDialog progressMonitor = new ProgressMonitorDialog(Display.getDefault().getActiveShell());
@@ -217,12 +247,54 @@ public class ResourcesPluginUtil {
     }
 
     /**
+     * Returns the file path of the templates jar
+     * @param isSource
+     *            true if we want to get source jar file path
+     * @return fileName Name of the jar downloaded
+     */
+    public static String getJarPath(boolean isSource) {
+
+        String fileName = "";
+
+        File templatesDirectory = getTemplatesDirectory();
+
+        File[] jarFiles;
+
+        if (isSource) {
+            jarFiles = templatesDirectory.listFiles(fileNameFilterSources);
+        } else {
+            jarFiles = templatesDirectory.listFiles(fileNameFilterJar);
+        }
+
+        if (jarFiles.length > 0) {
+            fileName = jarFiles[0].getPath().substring(jarFiles[0].getPath().lastIndexOf(File.separator) + 1);
+        }
+
+        return fileName;
+    }
+
+    /**
+     * Gets or creates a new templates directory
+     * @return the templateDirectory
+     */
+    private static File getTemplatesDirectory() {
+        File templatesDirectory = new File(ResourcesPlugin.getWorkspace().getRoot().getLocation().toPortableString()
+            + ResourceConstants.DOWNLOADED_JAR_FOLDER);
+        if (!templatesDirectory.exists()) {
+            templatesDirectory.mkdir();
+        }
+        return templatesDirectory;
+    }
+
+    /**
      * Process Jar method is responsible for unzip the source Jar and create new CobiGen_Templates folder
      * structure at /main/CobiGen_Templates location
      * @param fileName
      *            Name of source jar file downloaded
+     * @throws IOException
+     * @throws MalformedURLException
      */
-    public static void processJar(String fileName) {
+    public static void processJar(String fileName) throws MalformedURLException, IOException {
         String pathForCobigenTemplates = "";
         IPath ws = ResourcesPluginUtil.getWorkspaceLocation();
 
@@ -248,6 +320,57 @@ public class ResourcesPluginUtil {
             cobigenFolderPath = fileSystem.getPath(pathForCobigenTemplates);
         }
 
+        // If we are unzipping a sources jar, we need to get the pom.xml from the normal jar
+        if (fileName.contains("sources")) {
+            String classJarName = getJarPath(false);
+            if (classJarName.equals("")) {
+                classJarName = downloadJar(false);
+            }
+            String classJarPath = ws.toPortableString() + ResourceConstants.DOWNLOADED_JAR_FOLDER + "/" + classJarName;
+
+            try (ZipFile file = new ZipFile(classJarPath)) {
+                Enumeration<? extends ZipEntry> entries = file.entries();
+                Path cobigenTemplatesFolderPath = null;
+                if (fileSystem != null && fileSystem.getPath(pathForCobigenTemplates) != null) {
+                    cobigenTemplatesFolderPath =
+                        fileSystem.getPath(pathForCobigenTemplates + File.separator + COBIGEN_TEMPLATES);
+                }
+
+                if (cobigenTemplatesFolderPath == null) {
+                    throw new IOException(
+                        "An exception occurred while processing Jar files to create CobiGen_Templates folder");
+                }
+
+                if (Files.notExists(cobigenTemplatesFolderPath)) {
+                    Files.createDirectory(cobigenTemplatesFolderPath);
+                }
+                while (entries.hasMoreElements()) {
+                    ZipEntry entry = entries.nextElement();
+                    if (entry.getName().equals("pom.xml")) {
+                        Path saveForFileCreationPath = fileSystem.getPath(cobigenFolderPath + File.separator
+                            + COBIGEN_TEMPLATES + File.separator + File.separator + entry.getName());
+
+                        Files.deleteIfExists(saveForFileCreationPath);
+                        Files.createFile(saveForFileCreationPath);
+                        try (InputStream is = file.getInputStream(entry);
+                            BufferedInputStream bis = new BufferedInputStream(is);
+                            FileOutputStream fileOutput = new FileOutputStream(saveForFileCreationPath.toString());) {
+
+                            while (bis.available() > 0) {
+                                fileOutput.write(bis.read());
+                            }
+
+                        }
+                    }
+                }
+            } catch (IOException e) {
+
+                LOG.error("An exception occurred while processing Jar files to create CobiGen_Templates folder", e);
+                PlatformUIUtil.openErrorDialog(
+                    "An exception occurred while processing Jar file to create CobiGen_Templates folder", e);
+            }
+        }
+
         List<String> templateNames = new ArrayList<>();
         try (ZipFile file = new ZipFile(jarPath)) {
             Enumeration<? extends ZipEntry> entries = file.entries();
@@ -256,15 +379,15 @@ public class ResourcesPluginUtil {
             }
             while (entries.hasMoreElements()) {
                 ZipEntry entry = entries.nextElement();
-                Path saveForFileCreationPath = fileSystem.getPath(cobigenFolderPath + File.separator
-                    + "CobiGen_Templates" + File.separator + File.separator + entry.getName());
+                Path saveForFileCreationPath = fileSystem.getPath(cobigenFolderPath + File.separator + COBIGEN_TEMPLATES
+                    + File.separator + File.separator + entry.getName());
                 if (templateNames.parallelStream().anyMatch(entry.getName()::contains)
                     || entry.getName().contains("context.xml")) {
-                    saveForFileCreationPath = fileSystem.getPath(cobigenFolderPath + File.separator
-                        + "CobiGen_Templates" + File.separator + File.separator + entry.getName());
+                    saveForFileCreationPath = fileSystem.getPath(cobigenFolderPath + File.separator + COBIGEN_TEMPLATES
+                        + File.separator + File.separator + entry.getName());
                 } else if (entry.getName().contains("com/")) {
                     saveForFileCreationPath = fileSystem
-                        .getPath(cobigenFolderPath + File.separator + "CobiGen_Templates" + File.separator + "src"
+                        .getPath(cobigenFolderPath + File.separator + COBIGEN_TEMPLATES + File.separator + "src"
                             + File.separator + "main" + File.separator + "java" + File.separator + entry.getName());
                 }
                 if (entry.isDirectory()) {

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/generator/GeneratorWrapperFactory.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/generator/GeneratorWrapperFactory.java
@@ -11,6 +11,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
@@ -220,7 +221,11 @@ public class GeneratorWrapperFactory {
                         + " that you have no internet connection.");
             }
 
-            if (null == generatorProj.getLocationURI()) {
+            // We need to check whether it is a valid Java Project
+            IJavaProject configJavaProject = JavaCore.create(generatorProj);
+
+            // If it is not valid, we should use the jar
+            if (null == generatorProj.getLocationURI() || !configJavaProject.exists()) {
                 String fileName = ResourcesPluginUtil.downloadJar(false);
                 IPath ws = ResourcesPluginUtil.getWorkspaceLocation();
                 File file =

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/updatetemplates/UpdateTemplatesDialog.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/updatetemplates/UpdateTemplatesDialog.java
@@ -99,7 +99,7 @@ public class UpdateTemplatesDialog extends Dialog {
         GridData rightGridData = new GridData(GridData.CENTER, GridData.CENTER, false, false);
         rightGridData.widthHint = 80;
         Label label = new Label(contentParent, SWT.NONE);
-        label.setText("templates-oasp4j");
+        label.setText("templates-devon4j");
         label.setLayoutData(leftGridData);
         MDC.remove(InfrastructureConstants.CORRELATION_ID);
         return contentParent;


### PR DESCRIPTION
There was an error when using the Jars, so that the utils java files were not loaded properly. Also when adapting the templates, the pom.xml was not added. This has been fixed too.

Unfortunately, some code has been duplicated as we are on a hurry to release. We should refactor this code in the future.

I have tested multiple cases and it seems it is working fine.

@devonfw/cobigen
