### PR TITLE
Eclipse_plugin parsing both components and services

### DIFF
--- a/cobigen-eclipse/cobigen-eclipse-test/src/main/java/com/devonfw/cobigen/eclipse/test/OpenAPITest.java
+++ b/cobigen-eclipse/cobigen-eclipse-test/src/main/java/com/devonfw/cobigen/eclipse/test/OpenAPITest.java
@@ -141,7 +141,7 @@ public class OpenAPITest extends SystemTest {
     }
 
     /**
-     * Test for external projects (not in workspace) taken as input for generation
+     * Testing generation for ComponentDefs
      * @throws Exception
      *             test fails
      */

--- a/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/context.xml
+++ b/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/context.xml
@@ -8,4 +8,12 @@
       <variableAssignment type="property" key="entityName" value="name"/>
     </matcher>
   </trigger>
+  <trigger id="crud_openapi_angular_service_based_app" type="openapi" templateFolder="templates_service">
+    <containerMatcher type="element" value="openAPIFile"/>
+    <matcher type="element" value="ComponentDef">
+      <variableAssignment type="constant" key="domain" value="demo"/>
+      <variableAssignment type="property" key="component" value="name"/>
+      <variableAssignment type="property" key="etoName" value="name"/>
+    </matcher>
+  </trigger>
 </contextConfiguration>

--- a/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/templates/templates.xml
+++ b/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/templates/templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <templatesConfiguration xmlns="http://capgemini.com/devonfw/cobigen/TemplatesConfiguration" version="2.1">
 	<templates>
-    	<templateExtension ref="${variables.component#cap_first}RestService.java" mergeStrategy="javamerge"/>      
+    	<templateExtension ref="${variables.component#cap_first}RestService.java" mergeStrategy="javamerge"/>
     </templates>
     
     <templateScans>

--- a/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/templates_service/templates.xml
+++ b/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/templates_service/templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <templatesConfiguration xmlns="http://capgemini.com/devonfw/cobigen/TemplatesConfiguration" version="2.1">
 	<templates>
-    	<templateExtension ref="${variables.component#cap_first}RestService.java" mergeStrategy="javamerge"/>      
+      <templateExtension ref="${variables.component#lower_case}RestController.service.ts" mergeStrategy="tsmerge"/>
     </templates>
     
     <templateScans>
@@ -9,8 +9,8 @@
   	</templateScans>
   	
     <increments>
-	    <increment name="rest_service_impl" description="CRUD REST services">
-	      <templateRef ref="${variables.component#cap_first}RestService.java"/>
-	    </increment>
+      <increment name="app_angular_devon4j_component" description="View Component">
+        <templateRef ref="${variables.component#lower_case}RestController.service.ts"/>
+      </increment>
     </increments>
 </templatesConfiguration>

--- a/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/templates_service/templates/app/api/${variables.component#lower_case}/${variables.component#lower_case}RestController.service.ts.ftl
+++ b/cobigen-eclipse/cobigen-eclipse-test/src/main/resources/OpenAPITest/templates/templates_service/templates/app/api/${variables.component#lower_case}/${variables.component#lower_case}RestController.service.ts.ftl
@@ -1,0 +1,56 @@
+<#assign entityRef = "false">
+
+<#list model.paths as path>
+  <#list path.operations as operation>
+    <#list operation.responses as response>
+      <#if response.entityRef??>
+        <#assign entityRef = response.entityRef>        
+      </#if>      
+    </#list>
+  </#list>
+</#list>
+
+<#if entityRef != "false">
+import {${entityRef.name}} from '../model/${entityRef.name?lower_case}Eto';
+</#if>
+
+@Injectable()
+export class ${variables.component}RestControllerService {
+  <#list model.paths as path>
+      <#list path.operations as operation>
+    <#compress>
+      
+    /**
+    * <#if operation.type??> Operation type: ${operation.type} </#if>
+    * <#if operation.description??> Operation description: ${operation.description} </#if>
+    * <#if operation.tag??> Operation tag:<#list operation.tags as tag> ${operation.tag} </#list> </#if>
+    * <#if operation.responses??> <#list operation.responses as response> <#if response.type??> Response type: ${response.type} </#if>
+    <#if response.code??>* Response code: ${response.code} </#if>
+    <#if response.description??>* Response description: ${response.description} </#if>
+    * <#if response.mediaTypes??> <#list response.mediaTypes as mediaType> Media Type: ${mediaType} </#list> </#if> 
+    * <#if response.parameters??> <#list response.parameters as parameter> Parameter: ${parameter.mediaType} </#list> </#if> </#list> </#if>
+    **/   
+    
+    <#if path.version??>  
+    /**
+    * Path version: ${path.version}
+    **/
+    </#if>
+    </#compress>
+    
+    
+    /**
+     * <#if operation.operationId??>${operation.operationId}</#if>
+     * 
+     * @param query query
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
+    public <#if operation.operationId??>${operation.operationId}</#if>(query?: string, observe?: 'body', reportProgress?: boolean): Observable<<#if entityRef != "false">${entityRef.name}</#if>>{
+
+        return this.httpClient.get<<#if entityRef != "false">${entityRef.name}</#if>>(`${r"${this.basePath}"}/${variables.component?lower_case}<#if operation.summary??>/${operation.summary}/</#if><#if path.pathURI??>${path.pathURI}</#if>${r"${encodeURIComponent(String(query))}"}`;
+    }
+      </#list>
+  </#list>
+
+}

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/generator/CobiGenWrapper.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/generator/CobiGenWrapper.java
@@ -805,6 +805,17 @@ public abstract class CobiGenWrapper extends AbstractCobiGenWrapper {
         return children;
     }
 
+    /**
+     * Lambda function used to filter a list by an item property. It will return a list of items that meet the
+     * condition without duplicates. For instance, we use this for just getting a list of the inputs that have
+     * different types (instead of having 5 entities and 4 components, we would have just one entity and one
+     * component on the list)
+     * @param <T>
+     *            Any kind of object will be used
+     * @param typeExtractor
+     *            the function (condition) that will be applied to the list
+     * @return a filtered list without duplicated values on the property
+     */
     public static <T> Predicate<T> distinctByType(Function<? super T, ?> typeExtractor) {
         Set<Object> seen = ConcurrentHashMap.newKeySet();
         return t -> seen.add(typeExtractor.apply(t));

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/generator/CobiGenWrapper.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/generator/CobiGenWrapper.java
@@ -797,7 +797,6 @@ public abstract class CobiGenWrapper extends AbstractCobiGenWrapper {
             return null;
         }
 
-        // we currently only supporting one container at a time as valid selection
         List<Object> children = cobiGen.resolveContainers(inputs.get(0));
 
         // We only want distinct values (objects with different types) from the list

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/generator/CobiGenWrapper.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/generator/CobiGenWrapper.java
@@ -647,6 +647,8 @@ public abstract class CobiGenWrapper extends AbstractCobiGenWrapper {
     private <T extends IncrementTo> Map<String, Set<TemplateTo>> getTemplateDestinationPaths(Collection<T> increments,
         Object input) {
 
+        List<IncrementTo> matchingIncrements = cobiGen.getMatchingIncrements(input);
+
         boolean cachingEnabled = input == getCurrentRepresentingInput();
 
         Map<String, Set<TemplateTo>> result = Maps.newHashMap();
@@ -667,16 +669,16 @@ public abstract class CobiGenWrapper extends AbstractCobiGenWrapper {
 
             // Now we need to check whether the input matches the increment
             boolean inputNotMatchesIncrement = true;
-            for (IncrementTo inc : cobiGen.getMatchingIncrements(input)) {
+            for (IncrementTo inc : matchingIncrements) {
                 // If at least one triggerID is present, then the input is valid for this increment
                 if (inc.getTriggerId().equals(increment.getTriggerId())) {
                     inputNotMatchesIncrement = false;
                     break;
                 }
             }
-            // If it does not match, we should not keep the execution
+            // If it does not match, we should not keep the execution for this increment
             if (inputNotMatchesIncrement) {
-                break;
+                continue;
             }
 
             // process normal


### PR DESCRIPTION
Adresses #786 .

Implements the ability to define triggers with different matcher types for the same input file. For instance, now you are able to have two triggers, that get activated with an OpenAPI file, using different matchers like `ComponentDef` and `EntityDef`. This is useful for:

* Generating services independently from the components.

This should be merged alongside the `openapi_plugin` changes that have already a PR #810. Also I need to update the documentation with this new feature.

@devonfw/cobigen
Relates to [DEVC-77](https://icsdtheater.s2-eu.capgemini.com/jira/browse/DEVC-77)