### PR TITLE
Automatically convert CobiGen_Templates to a Maven project

### DIFF
--- a/cobigen-eclipse/cobigen-eclipse/META-INF/MANIFEST.MF
+++ b/cobigen-eclipse/cobigen-eclipse/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.104.0",
  org.eclipse.core.runtime;bundle-version="3.8.0",
  org.eclipse.ui.navigator;bundle-version="3.5.200",
  org.eclipse.ui.navigator.resources;bundle-version="3.4.400",
+ org.eclipse.m2e.core.ui;bundle-version="1.6.0",
  org.eclipse.core.filesystem;bundle-version="1.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Adresses #807.

This PR implements a way to automatically convert _CobiGen_Templates_ to a Maven project. It works fine, though my implementation is indeed hackish:

I have really tried to find a way to execute the command _configure -> to Maven project_ programmatically, but I did not find any good documentation explaining this.

The way I have implemented the solution is by directly calling the Eclipse Class that contains that logic ([EnableNatureAction](https://github.com/jibx/jibx-eclipse/blob/master/jibx-eclipse-plugin/src/org/jibx/eclipse/builder/EnableNatureAction.java)).

The drawback here is that the class is not API and I get the following warning:

![image](https://user-images.githubusercontent.com/31688036/50480946-37cc3e80-09df-11e9-9485-442a4f41c2af.png)

If there is a better solution, I would like to hear it. From the Spy plug-in this is the information I have retrieved:

```txt
The active contribution item identifier:
org.eclipse.m2e.enableNatureAction

The active contribution location URI:
menu:org.eclipse.ui.projectConfigure?after=org.eclipse.m2e.enableNatureAction

The active contribution item class:
EnableNatureAction

The contributing plug-in:
org.eclipse.ui.workbench (3.107.1.v20160120-2131)
```

@devonfw/cobigen
