### PR TITLE
Move update templates methods to core

### DIFF
--- a/cobigen/cobigen-core-parent/cobigen-core-api/src/main/java/com/devonfw/cobigen/api/constants/TemplatesJarConstants.java
+++ b/cobigen/cobigen-core-parent/cobigen-core-api/src/main/java/com/devonfw/cobigen/api/constants/TemplatesJarConstants.java
@@ -1,0 +1,35 @@
+package com.devonfw.cobigen.api.constants;
+
+/**
+ * Constants needed for handling the templates jar
+ */
+public class TemplatesJarConstants {
+    /**
+     * Latest Jar folder downloaded from Update Templates
+     */
+    public static final String DOWNLOADED_JAR_FOLDER = "/.metadata/cobigen_jars";
+
+    /**
+     * Jar regular expression name to be used in a file name filter, so that we can check whether the
+     * templates are already downloaded. Checks "templates-anystring-anydigitbetweendots.jar"
+     */
+    public static final String JAR_FILE_REGEX_NAME = "templates-([^-]+)-(\\d+\\.?)+.jar";
+
+    /**
+     * Source jar regular expression name to be used in a file name filter, so that we can check whether the
+     * templates are already downloaded. Checks "templates-anystring-anydigitbetweendots-sources.jar"
+     */
+    public static final String SOURCES_FILE_REGEX_NAME = "templates-([^-]+)-(\\d+\\.?)+-sources.jar";
+
+    /**
+     * Jar regular expression used to check the version of the jar in oder to find out whether we should
+     * update. Checks "templates-anystring-capturedigitsbetweendots.jar"
+     */
+    public static final String JAR_VERSION_REGEX_CHECK = "templates-([^-]+)-(\\d+|\\d+(\\.\\d+)*)?\\.jar";
+
+    /**
+     * Sources jar regular expression used to check the version of the sources jar in oder to find out whether
+     * we should update. Checks "templates-anystring-capturedigitsbetweendots-sources.jar"
+     */
+    public static final String SOURCES_VERSION_REGEX_CHECK = "templates-([^-]+)-(\\d+|\\d+(\\.\\d+)*)?\\-sources.jar";
+}

--- a/cobigen/cobigen-core-parent/cobigen-core-api/src/main/java/com/devonfw/cobigen/api/constants/TemplatesJarConstants.java
+++ b/cobigen/cobigen-core-parent/cobigen-core-api/src/main/java/com/devonfw/cobigen/api/constants/TemplatesJarConstants.java
@@ -34,8 +34,12 @@ public class TemplatesJarConstants {
     public static final String SOURCES_VERSION_REGEX_CHECK = "templates-([^-]+)-(\\d+|\\d+(\\.\\d+)*)?\\-sources.jar";
 
     /**
-     * URL of the latest devon4j templates jar on Maven Central
+     * GroupId of the latest devon4j templates jar on Maven Central
      */
-    public static final String DEVON4J_TEMPLATES_MAVEN_URL =
-        "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.devonfw.cobigen&a=templates-devon4j&v=LATEST";
+    public static final String DEVON4J_TEMPLATES_GROUPID = "com.devonfw.cobigen";
+
+    /**
+     * ArtifactId of the latest devon4j templates jar on Maven Central
+     */
+    public static final String DEVON4J_TEMPLATES_ARTIFACTID = "templates-devon4j";
 }

--- a/cobigen/cobigen-core-parent/cobigen-core-api/src/main/java/com/devonfw/cobigen/api/constants/TemplatesJarConstants.java
+++ b/cobigen/cobigen-core-parent/cobigen-core-api/src/main/java/com/devonfw/cobigen/api/constants/TemplatesJarConstants.java
@@ -32,4 +32,10 @@ public class TemplatesJarConstants {
      * we should update. Checks "templates-anystring-capturedigitsbetweendots-sources.jar"
      */
     public static final String SOURCES_VERSION_REGEX_CHECK = "templates-([^-]+)-(\\d+|\\d+(\\.\\d+)*)?\\-sources.jar";
+
+    /**
+     * URL of the latest devon4j templates jar on Maven Central
+     */
+    public static final String DEVON4J_TEMPLATES_MAVEN_URL =
+        "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.devonfw.cobigen&a=templates-devon4j&v=LATEST";
 }

--- a/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/util/TemplatesJarUtil.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/util/TemplatesJarUtil.java
@@ -130,39 +130,9 @@ public class TemplatesJarUtil {
      */
     public static String downloadLatestDevon4jTemplates(boolean isDownloadSource, File templatesDirectory)
         throws MalformedURLException, IOException {
-        String mavenUrl = TemplatesJarConstants.DEVON4J_TEMPLATES_MAVEN_URL;
-        if (isDownloadSource) {
-            mavenUrl = mavenUrl + "&c=sources";
-        }
 
-        String fileName = "";
-
-        File[] jarFiles;
-
-        if (isDownloadSource) {
-            jarFiles = templatesDirectory.listFiles(fileNameFilterSources);
-        } else {
-            jarFiles = templatesDirectory.listFiles(fileNameFilterJar);
-        }
-
-        if (jarFiles.length <= 0 || isJarOutdated(jarFiles[0], mavenUrl, isDownloadSource, templatesDirectory)) {
-
-            HttpURLConnection conn = initializeConnection(mavenUrl);
-            try (InputStream inputStream = conn.getInputStream()) {
-
-                fileName = conn.getURL().getFile().substring(conn.getURL().getFile().lastIndexOf("/") + 1);
-                File file = new File(templatesDirectory.getPath() + File.separator + fileName);
-                Path targetPath = file.toPath();
-                if (!file.exists()) {
-                    Files.copy(inputStream, targetPath, StandardCopyOption.REPLACE_EXISTING);
-                }
-            }
-            conn.disconnect();
-        } else {
-            fileName = jarFiles[0].getPath().substring(jarFiles[0].getPath().lastIndexOf(File.separator) + 1);
-
-        }
-        return fileName;
+        return downloadJar(TemplatesJarConstants.DEVON4J_TEMPLATES_GROUPID,
+            TemplatesJarConstants.DEVON4J_TEMPLATES_ARTIFACTID, "LATEST", isDownloadSource, templatesDirectory);
     }
 
     /**

--- a/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/util/TemplatesJarUtil.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/util/TemplatesJarUtil.java
@@ -1,0 +1,238 @@
+package com.devonfw.cobigen.impl.util;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.devonfw.cobigen.api.constants.TemplatesJarConstants;
+
+/**
+ *
+ */
+public class TemplatesJarUtil {
+
+    /**
+     * Filters the files on a directory so that we can check whether the templates jar are already downloaded
+     */
+    static FilenameFilter fileNameFilterJar = new FilenameFilter() {
+
+        @Override
+        public boolean accept(File dir, String name) {
+            String lowercaseName = name.toLowerCase();
+            String regex = TemplatesJarConstants.JAR_FILE_REGEX_NAME;
+
+            Pattern p = Pattern.compile(regex);
+            Matcher m = p.matcher(lowercaseName);
+            if (m.find()) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    };
+
+    /**
+     * Filters the files on a directory so that we can check whether the templates jar are already downloaded
+     */
+    static FilenameFilter fileNameFilterSources = new FilenameFilter() {
+
+        @Override
+        public boolean accept(File dir, String name) {
+            String lowercaseName = name.toLowerCase();
+            String regex = TemplatesJarConstants.SOURCES_FILE_REGEX_NAME;
+
+            Pattern p = Pattern.compile(regex);
+            Matcher m = p.matcher(lowercaseName);
+            if (m.find()) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    };
+
+    /**
+     * @param isDownloadSource
+     *            true if downloading source jar file
+     * @param templatesDirectory
+     *            directory where the templates jar are located
+     * @return fileName Name of the file downloaded
+     * @throws MalformedURLException
+     *             {@link MalformedURLException} occurred
+     * @throws IOException
+     *             {@link IOException} occurred
+     */
+    public static String downloadJar(boolean isDownloadSource, File templatesDirectory)
+        throws MalformedURLException, IOException {
+        String mavenUrl =
+            "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.devonfw.cobigen&a=templates-devon4j&v=LATEST";
+        if (isDownloadSource) {
+            mavenUrl = mavenUrl + "&c=sources";
+        }
+
+        String fileName = "";
+
+        File[] jarFiles;
+
+        if (isDownloadSource) {
+            jarFiles = templatesDirectory.listFiles(fileNameFilterSources);
+        } else {
+            jarFiles = templatesDirectory.listFiles(fileNameFilterJar);
+        }
+
+        if (jarFiles.length <= 0 || isJarOutdated(jarFiles[0], mavenUrl, isDownloadSource, templatesDirectory)) {
+
+            HttpURLConnection conn = initializeConnection(mavenUrl);
+            InputStream inputStream = conn.getInputStream();
+            fileName = conn.getURL().getFile().substring(conn.getURL().getFile().lastIndexOf("/") + 1);
+            File file = new File(templatesDirectory.getPath() + File.separator + fileName);
+            Path targetPath = file.toPath();
+            if (!file.exists()) {
+                Files.copy(inputStream, targetPath, StandardCopyOption.REPLACE_EXISTING);
+            }
+            conn.disconnect();
+        } else {
+            fileName = jarFiles[0].getPath().substring(jarFiles[0].getPath().lastIndexOf(File.separator) + 1);
+
+        }
+        return fileName;
+    }
+
+    /**
+     * Checks whether there is a newer version of the templates on Maven
+     * @param jarFile
+     *            our jar file that we want to check
+     * @param mavenUrl
+     *            the URL from where we are going to retrieve the latest jar
+     * @param isDownloadSource
+     *            true if downloading source jar file
+     * @param templatesDirectory
+     *            directory where the templates jar are located
+     * @return true if our jar is outdated false otherwise
+     * @throws IOException
+     *             {@link IOException} occurred
+     * @throws ProtocolException
+     *             {@link ProtocolException} occurred
+     * @throws MalformedURLException
+     *             {@link MalformedURLException} occurred
+     */
+    private static boolean isJarOutdated(File jarFile, String mavenUrl, boolean isDownloadSource,
+        File templatesDirectory) throws MalformedURLException, ProtocolException, IOException {
+        String fileName = jarFile.getPath().substring(jarFile.getPath().lastIndexOf(File.separator) + 1);
+        Matcher m = matchJarVersion(fileName, isDownloadSource);
+        if (m.find() == false || m.group(2).isEmpty()) {
+            // Maybe the jar is corrupted, let's update it
+            return true;
+        } else {
+            // Split the version number because it contains dots e.g. 3.1.0
+            int[] versionNumbers = Arrays.stream(m.group(2).split("\\.")).mapToInt(Integer::parseInt).toArray();
+
+            // We do the same for the latest jar in Maven, therefore we need to download it
+            HttpURLConnection conn = initializeConnection(mavenUrl);
+            conn.getInputStream();
+            String latestJar = conn.getURL().getFile().substring(conn.getURL().getFile().lastIndexOf("/") + 1);
+            m = matchJarVersion(latestJar, isDownloadSource);
+            if (m.find() == false || m.group(2).isEmpty()) {
+                return false;
+            }
+            // Split the version number because it contains dots e.g. 3.1.0
+            int[] versionNumbersLatest = Arrays.stream(m.group(2).split("\\.")).mapToInt(Integer::parseInt).toArray();
+
+            for (int i = 0; i < versionNumbersLatest.length; i++) {
+                if (versionNumbersLatest[i] > versionNumbers[i]) {
+                    if (isDownloadSource == false) {
+                        // we now need to download the latest sources
+                        downloadJar(true, templatesDirectory);
+                    }
+                    jarFile.delete();
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+    }
+
+    /**
+     * Used for matching the jar version. For instance, we want to match "3.0.0" from templates-devon4j-3.0.0
+     * @param fileName
+     *            String to get matched by the regex
+     * @param isDownloadSource
+     *            true if downloading source jar file
+     * @return the Matcher
+     */
+    private static Matcher matchJarVersion(String fileName, boolean isDownloadSource) {
+        String lowercaseName = fileName.toLowerCase();
+        String regex = TemplatesJarConstants.JAR_VERSION_REGEX_CHECK;
+        if (isDownloadSource) {
+            regex = TemplatesJarConstants.SOURCES_VERSION_REGEX_CHECK;
+        }
+
+        Pattern p = Pattern.compile(regex);
+        Matcher m = p.matcher(lowercaseName);
+        return m;
+    }
+
+    /**
+     * Initializes a new connection to the specified Maven URL
+     * @param mavenUrl
+     *            the URL we need to connect to
+     * @return the connection instance
+     * @throws MalformedURLException
+     *             if the URL is invalid
+     * @throws IOException
+     *             if we could not connect properly
+     * @throws ProtocolException
+     *             if the request protocol is invalid
+     */
+    private static HttpURLConnection initializeConnection(String mavenUrl)
+        throws MalformedURLException, IOException, ProtocolException {
+        URL url = new URL(mavenUrl);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.connect();
+        return conn;
+    }
+
+    /**
+     * Returns the file path of the templates jar
+     * @param isSource
+     *            true if we want to get source jar file path
+     * @param templatesDirectory
+     *            directory where the templates are located
+     * @return fileName Name of the jar downloaded or null if it was not found
+     */
+    public static String getJarPath(boolean isSource, File templatesDirectory) {
+
+        String fileName = "";
+
+        File[] jarFiles;
+
+        if (isSource) {
+            jarFiles = templatesDirectory.listFiles(fileNameFilterSources);
+        } else {
+            jarFiles = templatesDirectory.listFiles(fileNameFilterJar);
+        }
+
+        if (jarFiles.length > 0) {
+            fileName = jarFiles[0].getPath().substring(jarFiles[0].getPath().lastIndexOf(File.separator) + 1);
+        } else {
+            // There are no jars downlaoded
+            return null;
+        }
+
+        return fileName;
+    }
+}

--- a/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/util/TemplatesJarUtil.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/util/TemplatesJarUtil.java
@@ -100,12 +100,14 @@ public class TemplatesJarUtil {
         if (jarFiles.length <= 0 || isJarOutdated(jarFiles[0], mavenUrl, isDownloadSource, templatesDirectory)) {
 
             HttpURLConnection conn = initializeConnection(mavenUrl);
-            InputStream inputStream = conn.getInputStream();
-            fileName = conn.getURL().getFile().substring(conn.getURL().getFile().lastIndexOf("/") + 1);
-            File file = new File(templatesDirectory.getPath() + File.separator + fileName);
-            Path targetPath = file.toPath();
-            if (!file.exists()) {
-                Files.copy(inputStream, targetPath, StandardCopyOption.REPLACE_EXISTING);
+            try (InputStream inputStream = conn.getInputStream()) {
+
+                fileName = conn.getURL().getFile().substring(conn.getURL().getFile().lastIndexOf("/") + 1);
+                File file = new File(templatesDirectory.getPath() + File.separator + fileName);
+                Path targetPath = file.toPath();
+                if (!file.exists()) {
+                    Files.copy(inputStream, targetPath, StandardCopyOption.REPLACE_EXISTING);
+                }
             }
             conn.disconnect();
         } else {
@@ -146,12 +148,14 @@ public class TemplatesJarUtil {
         if (jarFiles.length <= 0 || isJarOutdated(jarFiles[0], mavenUrl, isDownloadSource, templatesDirectory)) {
 
             HttpURLConnection conn = initializeConnection(mavenUrl);
-            InputStream inputStream = conn.getInputStream();
-            fileName = conn.getURL().getFile().substring(conn.getURL().getFile().lastIndexOf("/") + 1);
-            File file = new File(templatesDirectory.getPath() + File.separator + fileName);
-            Path targetPath = file.toPath();
-            if (!file.exists()) {
-                Files.copy(inputStream, targetPath, StandardCopyOption.REPLACE_EXISTING);
+            try (InputStream inputStream = conn.getInputStream()) {
+
+                fileName = conn.getURL().getFile().substring(conn.getURL().getFile().lastIndexOf("/") + 1);
+                File file = new File(templatesDirectory.getPath() + File.separator + fileName);
+                Path targetPath = file.toPath();
+                if (!file.exists()) {
+                    Files.copy(inputStream, targetPath, StandardCopyOption.REPLACE_EXISTING);
+                }
             }
             conn.disconnect();
         } else {
@@ -192,9 +196,11 @@ public class TemplatesJarUtil {
 
             // We do the same for the latest jar in Maven, therefore we need to download it
             HttpURLConnection conn = initializeConnection(mavenUrl);
-            conn.getInputStream();
-            String latestJar = conn.getURL().getFile().substring(conn.getURL().getFile().lastIndexOf("/") + 1);
-            m = matchJarVersion(latestJar, isDownloadSource);
+            try (InputStream inputStream = conn.getInputStream()) {
+                String latestJar = conn.getURL().getFile().substring(conn.getURL().getFile().lastIndexOf("/") + 1);
+                m = matchJarVersion(latestJar, isDownloadSource);
+            }
+
             if (m.find() == false || m.group(2).isEmpty()) {
                 return false;
             }

--- a/cobigen/cobigen-core-parent/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/templates/TemplateJarDownloaderTest.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/templates/TemplateJarDownloaderTest.java
@@ -1,0 +1,48 @@
+package com.devonfw.cobigen.unittest.templates;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.devonfw.cobigen.impl.util.TemplatesJarUtil;
+import com.devonfw.cobigen.unittest.config.common.AbstractUnitTest;
+
+/**
+ * Test suite for {@link TemplatesJarUtil}
+ */
+public class TemplateJarDownloaderTest extends AbstractUnitTest {
+
+    /** Root path to all resources used in this test case */
+    private static String testFileRootPath = "src/test/resources/testdata/unittest/config/templatesJar/";
+
+    /** JUnit Rule to create and automatically cleanup temporarily files/folders */
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    /**
+     * Tests the valid upgrade of a templates jar
+     * @throws Exception
+     *             test fails
+     */
+    @Test
+    public void testCorrectTemplatesUpgrade() throws Exception {
+
+        // preparation
+        tempFolder.newFile("templates-devon4j-3.0.0.jar");
+        File tmpJarFolder = tempFolder.getRoot();
+
+        // Perform download
+        TemplatesJarUtil.downloadLatestDevon4jTemplates(false, tmpJarFolder);
+
+        // Assert
+        assertThat(tmpJarFolder.list().length).isEqualTo(2); // It should download also the sources
+        assertThat(tmpJarFolder.list()[0].contains("templates-devon4j-3.0.0")).isFalse();
+        assertThat(tmpJarFolder.list()[1].contains("templates-devon4j-3.0.0")).isFalse();
+
+    }
+
+}


### PR DESCRIPTION
Needed for #819 as we need to make available the methods related to the download of templates jar.

Changes:

* Moved all the needed methods for updating the jars to the core.
* Fixed some bugs, the updating of templates was not done correctly.
* Implemented a method to check if our current jar is outdated. May be useful in future with the CLI, to ask our user whether we should update the latest templates.

@devonfw/cobigen
