### PR TITLE
Improving increments structure

### DIFF
--- a/cobigen-templates/templates-devon4j/src/main/java/com/devonfw/cobigen/templates/oasp4j/utils/OpenApiUtil.java
+++ b/cobigen-templates/templates-devon4j/src/main/java/com/devonfw/cobigen/templates/oasp4j/utils/OpenApiUtil.java
@@ -181,6 +181,52 @@ public class OpenApiUtil {
         }
         return typeConverted;
     }
+    
+    /**
+     * Returns the TypeScript type corresponding to the OpenAPI type definition. If the type could not be matched,
+     * the same value will be returned.
+     * @param parameter
+     *            OpenAPI model of a parameter
+     * @return the Java type
+     */
+    // getOaspTypeFromOpenAPI
+    public String toTypeScriptType(Map<String, Object> parameter) {
+        String typeConverted = null;
+        String type = (String) parameter.get("type");
+        boolean isCollection = false;
+        if (parameter.get("isCollection") != null) {
+            isCollection = (boolean) parameter.get("isCollection");
+        }
+
+        boolean isEntity = (boolean) parameter.get("isEntity");
+
+        if (type != null) {
+            switch (type.toLowerCase()) {
+            case "integer":
+            	typeConverted = "number";
+                break;
+            case "number":
+            	typeConverted = "number";
+                break;
+            default:
+                typeConverted = "void";
+                break;
+            }
+        } else {
+            typeConverted = type;
+        }
+
+        if (isCollection) {
+            if (isEntity) {
+                return parameter.get("type") + "[]";
+            } else {
+                return typeConverted + "[]";
+            }
+        } else if (isEntity) {
+            return (String) parameter.get("type");
+        }
+        return typeConverted;
+    }
 
     /**
      * Prints the service operation name based on the operationId or generates one based on the servicePath

--- a/cobigen-templates/templates-devon4j/src/main/java/com/devonfw/cobigen/templates/oasp4j/utils/OpenApiUtil.java
+++ b/cobigen-templates/templates-devon4j/src/main/java/com/devonfw/cobigen/templates/oasp4j/utils/OpenApiUtil.java
@@ -207,15 +207,12 @@ public class OpenApiUtil {
             case "integer":
                 typeConverted = "number";
                 break;
-            case "number":
-                typeConverted = "number";
-                break;
             default:
                 typeConverted = type;
                 break;
             }
         } else {
-            typeConverted = "void";
+            typeConverted = "undefined";
         }
 
         if (isCollection) {

--- a/cobigen-templates/templates-devon4j/src/main/java/com/devonfw/cobigen/templates/oasp4j/utils/OpenApiUtil.java
+++ b/cobigen-templates/templates-devon4j/src/main/java/com/devonfw/cobigen/templates/oasp4j/utils/OpenApiUtil.java
@@ -57,19 +57,21 @@ public class OpenApiUtil {
         }
         if ((boolean) response.get("isArray")) {
             if ((boolean) response.get("isEntity")) {
-            	if(returnType.contains("Entity"))
-            		return "List<" + returnType + ">";
-            	else
-            		return "List<" + returnType + "Entity>";
+                if (returnType.contains("Entity")) {
+                    return "List<" + returnType + ">";
+                } else {
+                    return "List<" + returnType + "Entity>";
+                }
             } else {
                 return "List<" + returnType + ">";
             }
         } else if ((boolean) response.get("isPaginated")) {
             if ((boolean) response.get("isEntity")) {
-            	if(returnType.contains("Entity"))
-            		return "Page<" + returnType + ">";
-            	else
-            		return "Page<" + returnType + "Entity>";
+                if (returnType.contains("Entity")) {
+                    return "Page<" + returnType + ">";
+                } else {
+                    return "Page<" + returnType + "Entity>";
+                }
             } else {
                 return "Page<" + returnType + ">";
             }
@@ -181,10 +183,10 @@ public class OpenApiUtil {
         }
         return typeConverted;
     }
-    
+
     /**
-     * Returns the TypeScript type corresponding to the OpenAPI type definition. If the type could not be matched,
-     * the same value will be returned.
+     * Returns the TypeScript type corresponding to the OpenAPI type definition. If the type could not be
+     * matched, the same value will be returned.
      * @param parameter
      *            OpenAPI model of a parameter
      * @return the Java type
@@ -203,17 +205,17 @@ public class OpenApiUtil {
         if (type != null) {
             switch (type.toLowerCase()) {
             case "integer":
-            	typeConverted = "number";
+                typeConverted = "number";
                 break;
             case "number":
-            	typeConverted = "number";
+                typeConverted = "number";
                 break;
             default:
-                typeConverted = "void";
+                typeConverted = type;
                 break;
             }
         } else {
-            typeConverted = type;
+            typeConverted = "void";
         }
 
         if (isCollection) {

--- a/cobigen-templates/templates-devon4j/src/main/templates/crud_angular_client_app/templates.xml
+++ b/cobigen-templates/templates-devon4j/src/main/templates/crud_angular_client_app/templates.xml
@@ -20,7 +20,12 @@
   </templateScans>
 
   <increments>
-    <increment name="app_angular_structure" description="Angular devon4ng URL">
+    <increment name="devon4ng-app" description="CRUD devon4ng Angular App">
+      <incrementRef ref="app_angular_env"/>
+      <incrementRef ref="app_angular_i18n"/>
+      <incrementRef ref="app_angular_devon4ng_component"/>
+    </increment>
+    <increment name="app_angular_env" description="Angular devon4ng URL">
         <templateRef ref="environment.ts"/>
         <templateRef ref="environment.prod.ts"/>
     </increment>

--- a/cobigen-templates/templates-devon4j/src/main/templates/crud_ionic_client_app/templates.xml
+++ b/cobigen-templates/templates-devon4j/src/main/templates/crud_ionic_client_app/templates.xml
@@ -29,6 +29,13 @@
   </templateScans>
 
   <increments>
+  <increment name="devon4ng-app" description="CRUD devon4ng Ionic App">
+      <incrementRef ref="app_ionic_structure"/>
+      <incrementRef ref="ionic_routing"/>
+      <incrementRef ref="ionic_i18n"/>
+      <incrementRef ref="ionic_component"/>
+      <incrementRef ref="ionic_theme"/>
+    </increment>
     <increment name="app_ionic_structure" description="Ionic devon4ng environments">
       <templateRef ref="environment.android.ts" />
       <templateRef ref="environment.prod.ts" />

--- a/cobigen-templates/templates-devon4j/src/main/templates/crud_openapi_angular_client_app/templates/src/app/model/${variables.etoName#lower_case}.ts.ftl
+++ b/cobigen-templates/templates-devon4j/src/main/templates/crud_openapi_angular_client_app/templates/src/app/model/${variables.etoName#lower_case}.ts.ftl
@@ -16,7 +16,7 @@
 export interface ${variables.etoName?cap_first} {
 <#compress>
 <#list model.properties as property>
-    ${property.name}?: ${property.type};
+    ${property.name}?: ${OpenApiUtil.toTypeScriptType(property)};
 </#list>
 </#compress>
 


### PR DESCRIPTION
Improving increments structure, so that Angular and Ionic increments are better organized.

Also, I found that when an OpenAPI file defined an attribute with type `integer`, it was not getting correctly translated to `number` on TypeScript.

@devonfw/cobigen
