### PR TITLE
Misleading Javadoc and null pointer exception

### DIFF
--- a/cobigen-templates/templates-devon4j/src/main/templates/crud_java_server_app/templates/java/${variables.rootPackage}/${variables.component}/dataaccess/api/repo/${variables.entityName}Repository.java.ftl
+++ b/cobigen-templates/templates-devon4j/src/main/templates/crud_java_server_app/templates/java/${variables.rootPackage}/${variables.component}/dataaccess/api/repo/${variables.entityName}Repository.java.ftl
@@ -27,8 +27,8 @@ public interface ${variables.entityName}Repository extends DefaultRepository<${v
 
   /**
    * @param criteria the {@link ${variables.entityName}SearchCriteriaTo} with the criteria to search.
-   * @return the {@link Page} of the {@link ${variables.entityName}Entity} objects that matched the search when the pageable is
-   * set. If no pageable is set, it will return a unique page with all the objects from the database.
+   * @return the {@link Page} of the {@link ${variables.entityName}Entity} objects that matched the search.
+   * If no pageable is set, it will return a unique page with all the objects that matched the search.
    */
   default Page<${variables.entityName}Entity> findByCriteria(${variables.entityName}SearchCriteriaTo criteria) {
 

--- a/cobigen-templates/templates-devon4j/src/main/templates/crud_java_server_app/templates/java/${variables.rootPackage}/${variables.component}/dataaccess/api/repo/${variables.entityName}Repository.java.ftl
+++ b/cobigen-templates/templates-devon4j/src/main/templates/crud_java_server_app/templates/java/${variables.rootPackage}/${variables.component}/dataaccess/api/repo/${variables.entityName}Repository.java.ftl
@@ -27,8 +27,8 @@ public interface ${variables.entityName}Repository extends DefaultRepository<${v
 
   /**
    * @param criteria the {@link ${variables.entityName}SearchCriteriaTo} with the criteria to search.
-   * @param pageRequest {@link Pageable} implementation used to set page properties like page size
-   * @return the {@link Page} of the {@link ${variables.entityName}Entity} objects that matched the search.
+   * @return the {@link Page} of the {@link ${variables.entityName}Entity} objects that matched the search when the pageable is
+   * set. If no pageable is set, it will return a unique page with all the objects from the database.
    */
   default Page<${variables.entityName}Entity> findByCriteria(${variables.entityName}SearchCriteriaTo criteria) {
 
@@ -67,7 +67,11 @@ public interface ${variables.entityName}Repository extends DefaultRepository<${v
       </#compress>
     </#if>
     </#list>
-    addOrderBy(query, alias, criteria.getPageable().getSort());
+    if (criteria.getPageable() == null) {
+      criteria.setPageable(PageRequest.of(0, Integer.MAX_VALUE));
+    } else {
+      addOrderBy(query, alias, criteria.getPageable().getSort());
+    }
     
     return QueryUtil.get().findPaginated(criteria.getPageable(), query, true);
   }

--- a/cobigen-templates/templates-devon4j/src/main/templates/crud_openapi_java_server_app/templates/java/${variables.rootPackage}/${variables.component#lower_case}/dataaccess/api/repo/${variables.entityName}Repository.java.ftl
+++ b/cobigen-templates/templates-devon4j/src/main/templates/crud_openapi_java_server_app/templates/java/${variables.rootPackage}/${variables.component#lower_case}/dataaccess/api/repo/${variables.entityName}Repository.java.ftl
@@ -27,8 +27,8 @@ public interface ${variables.entityName}Repository extends DefaultRepository<${v
 
   /**
    * @param criteria the {@link ${variables.entityName}SearchCriteriaTo} with the criteria to search.
-   * @return the {@link Page} of the {@link ${variables.entityName}Entity} objects that matched the search when the pageable is
-   * set. If no pageable is set, it will return a unique page with all the objects from the database.
+   * @return the {@link Page} of the {@link ${variables.entityName}Entity} objects that matched the search.
+   * If no pageable is set, it will return a unique page with all the objects that matched the search.
    */
   default Page<${variables.entityName}Entity> findByCriteria(${variables.entityName}SearchCriteriaTo criteria) {
 

--- a/cobigen-templates/templates-devon4j/src/main/templates/crud_openapi_java_server_app/templates/java/${variables.rootPackage}/${variables.component#lower_case}/dataaccess/api/repo/${variables.entityName}Repository.java.ftl
+++ b/cobigen-templates/templates-devon4j/src/main/templates/crud_openapi_java_server_app/templates/java/${variables.rootPackage}/${variables.component#lower_case}/dataaccess/api/repo/${variables.entityName}Repository.java.ftl
@@ -27,8 +27,8 @@ public interface ${variables.entityName}Repository extends DefaultRepository<${v
 
   /**
    * @param criteria the {@link ${variables.entityName}SearchCriteriaTo} with the criteria to search.
-   * @param pageRequest {@link Pageable} implementation used to set page properties like page size
-   * @return the {@link Page} of the {@link ${variables.entityName}Entity} objects that matched the search.
+   * @return the {@link Page} of the {@link ${variables.entityName}Entity} objects that matched the search when the pageable is
+   * set. If no pageable is set, it will return a unique page with all the objects from the database.
    */
   default Page<${variables.entityName}Entity> findByCriteria(${variables.entityName}SearchCriteriaTo criteria) {
 
@@ -66,7 +66,11 @@ public interface ${variables.entityName}Repository extends DefaultRepository<${v
       </#compress>
     </#if>
     </#list>
-    addOrderBy(query, alias, criteria.getPageable().getSort());
+    if (criteria.getPageable() == null) {
+      criteria.setPageable(PageRequest.of(0, Integer.MAX_VALUE));
+    } else {
+      addOrderBy(query, alias, criteria.getPageable().getSort());
+    }
     
     return QueryUtil.get().findPaginated(criteria.getPageable(), query, true);
   }


### PR DESCRIPTION
Fixes #844.

Implements

* Changing misleading Javadoc, there was a non existing parameter declared on the Javadoc.
* A null pointer exception was thrown when `Pageable` parameter was not set.

@devonfw/cobigen
