### PR TITLE
Fixed stupid replacement bug

### DIFF
--- a/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/entity/Variables.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/entity/Variables.java
@@ -323,7 +323,7 @@ public class Variables {
                     CaseSyntax syntax = CaseSyntax.ofExample(variableKey, true);
                     variableValue = syntax.convert(variableValue);
                     if (containsDot) {
-                        variableValue.replace(DUMMY_LETTER_FOR_DOT, replacementForDot);
+                        variableValue = variableValue.replace(DUMMY_LETTER_FOR_DOT, replacementForDot);
                     }
                 } else {
                     variableValue = resolveFunction(variableValue, m.group(2));


### PR DESCRIPTION
Seems that the new variable syntax was never really used. As I am working on #158 I was hitting this stupid bug that does not remap the temporary character back ending up with crazy outcome.