### PR TITLE
Fixed stupid bug in replacement of dots for #158

### DIFF
--- a/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/entity/Variables.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/entity/Variables.java
@@ -323,7 +323,7 @@ public class Variables {
                     CaseSyntax syntax = CaseSyntax.ofExample(variableKey, true);
                     variableValue = syntax.convert(variableValue);
                     if (containsDot) {
-                        variableValue.replace(DUMMY_LETTER_FOR_DOT, replacementForDot);
+                        variableValue = variableValue.replace(DUMMY_LETTER_FOR_DOT, replacementForDot);
                     }
                 } else {
                     variableValue = resolveFunction(variableValue, m.group(2));


### PR DESCRIPTION
Replacement of dots with new variable syntax has a stupid bug where the re-substitution is not assigned back to the variable. Feature was obviously never tested before. Since I am working on #158 I hit the bug and wanna have it fixed.
