### PR TITLE
Cleaning Pipelines: Removing garbage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -203,6 +203,13 @@ node {
 					build job: 'dev_mavenplugin', wait: false, parameters: [[$class:'StringParameterValue', name:'TRIGGER_SHA', value:env.GIT_COMMIT], [$class:'StringParameterValue', name:'TRIGGER_REPO', value: repo]]
 				}
 			}
+			
+			post {
+				cleanup {
+					cleanWs()
+					deleteDir()
+				}
+			}
 
 		} catch(e) {
 			if (currentBuild.result != 'UNSTABLE') {
@@ -210,17 +217,18 @@ node {
 				setBuildStatus("Incomplete","ERROR")
 			}
 			notifyFailed()
+			
+			post {
+				cleanup {
+					cleanWs()
+					deleteDir()
+				}
+			}
+			
 			throw e
 		}
 		setBuildStatus("Complete","SUCCESS")
 	//}
-	
-	post {
-		cleanup {
-			cleanWs()
-			deleteDir()
-		}
-	}
 }
 
 def isPRBuild() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -214,6 +214,13 @@ node {
 		}
 		setBuildStatus("Complete","SUCCESS")
 	//}
+	
+	post {
+		cleanup {
+			cleanWs()
+			deleteDir()
+		}
+	}
 }
 
 def isPRBuild() {
@@ -252,4 +259,6 @@ def setBuildStatus(String message, String state) {
 		echo "Could not set build status for ${params.TRIGGER}: ${message}, ${state}"
 		echo "Exception ${e.toString()}:${e.getMessage()}"
 	}
+	
+
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -203,13 +203,6 @@ node {
 					build job: 'dev_mavenplugin', wait: false, parameters: [[$class:'StringParameterValue', name:'TRIGGER_SHA', value:env.GIT_COMMIT], [$class:'StringParameterValue', name:'TRIGGER_REPO', value: repo]]
 				}
 			}
-			
-			post {
-				cleanup {
-					cleanWs()
-					deleteDir()
-				}
-			}
 
 		} catch(e) {
 			if (currentBuild.result != 'UNSTABLE') {
@@ -229,6 +222,13 @@ node {
 		}
 		setBuildStatus("Complete","SUCCESS")
 	//}
+	
+	post {
+		cleanup {
+			cleanWs()
+			deleteDir()
+		}
+	}
 }
 
 def isPRBuild() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -211,11 +211,9 @@ node {
 			}
 			notifyFailed()
 			
-			post {
-				cleanup {
-					cleanWs()
-					deleteDir()
-				}
+			stage('clean up') {
+				cleanWs()
+				deleteDir()
 			}
 			
 			throw e
@@ -223,11 +221,9 @@ node {
 		setBuildStatus("Complete","SUCCESS")
 	//}
 	
-	post {
-		cleanup {
-			cleanWs()
-			deleteDir()
-		}
+	stage('clean up') {
+		cleanWs()
+		deleteDir()
 	}
 }
 


### PR DESCRIPTION
Add a clean up on the Jenkins file in order to remove garbage on our Production Line instance. This doesn't remove the build history nor the ability to check the workspace. It just removes the downloaded Eclipse instance.