### PR TITLE
Fixing failing test on XML plugin

### DIFF
--- a/cobigen/cobigen-xmlplugin/src/test/resources/testdata/unittest/merger/BasePom.xml
+++ b/cobigen/cobigen-xmlplugin/src/test/resources/testdata/unittest/merger/BasePom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/cobigen/cobigen-xmlplugin/src/test/resources/testdata/unittest/merger/PatchPom.xml
+++ b/cobigen/cobigen-xmlplugin/src/test/resources/testdata/unittest/merger/PatchPom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
An XML plugin test was failing when trying to merge two pom files. The problem was a validation error `cvc-elt.1.a: Cannot find the declaration of element 'project'`.

I have fixed it by adding some configuration to the pom file.