### PR TITLE
Fixing bug: External increment from jar

### DIFF
--- a/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/reader/TemplatesConfigurationReader.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/reader/TemplatesConfigurationReader.java
@@ -1,6 +1,5 @@
 package com.devonfw.cobigen.impl.config.reader;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
@@ -664,8 +663,7 @@ public class TemplatesConfigurationReader {
      */
     private com.devonfw.cobigen.impl.config.TemplatesConfiguration loadExternalConfig(String refTrigger) {
 
-        String contextPath = rootTemplateFolder.getPath().normalize().getParent().toString();
-        Trigger extTrigger = getExternalTrigger(refTrigger, contextPath);
+        Trigger extTrigger = getExternalTrigger(refTrigger);
         return configurationHolder.readTemplatesConfiguration(extTrigger);
     }
 
@@ -749,13 +747,11 @@ public class TemplatesConfigurationReader {
      * Tries to read the context.xml file for finding and returning an external trigger
      * @param triggerToSearch
      *            string containing the name of the trigger to search
-     * @param pathToContext
-     *            string containing the path to the context.xml file
      * @return the found external trigger
      */
-    private Trigger getExternalTrigger(String triggerToSearch, String pathToContext) {
+    private Trigger getExternalTrigger(String triggerToSearch) {
         ContextConfigurationReader contextConfigurationReader =
-            new ContextConfigurationReader(Paths.get(new File(pathToContext).toURI()));
+            new ContextConfigurationReader(configurationHolder.readContextConfiguration().getConfigurationPath());
         Map<String, Trigger> triggers = contextConfigurationReader.loadTriggers();
         Trigger trig = triggers.get(triggerToSearch);
         if (trig == null) {

--- a/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/externalprocess/ExternalProcessHandler.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/externalprocess/ExternalProcessHandler.java
@@ -508,7 +508,7 @@ public class ExternalProcessHandler {
         objWriter = new ObjectMapper().writer().withDefaultPrettyPrinter();
         String jsonMergerTo;
         try (OutputStream os = conn.getOutputStream();
-            OutputStreamWriter osw = new OutputStreamWriter(os, charsetName);) {
+            OutputStreamWriter osw = new OutputStreamWriter(os, Charset.forName(charsetName).newEncoder());) {
 
             jsonMergerTo = objWriter.writeValueAsString(dataTo);
             // We need to escape new lines because otherwise our JSON gets corrupted


### PR DESCRIPTION
We have found a bug when loading an external increment (increment defined in `templates.xml` different from current one) when we are using the templates jar.

We have not seen this error before because on the testing phase we always used CobiGen_Templates as an imported project.

@devonfw/cobigen
