### PR TITLE
Jenkins disabling concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ properties([
     string(name: 'TRIGGER_REPO', defaultValue: '', description: 'The URI of the commit that triggered the calling job')
    ]),
    [$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10']],
-   [disableConcurrentBuilds()]
+   disableConcurrentBuilds()
 ])
 node {
     //lock(resource: "pipeline_${env.NODE_NAME}_${env.JOB_NAME}", inversePrecedence: false) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,8 @@ properties([
     string(name: 'TRIGGER_SHA', defaultValue: '', description: 'The sha of the commit that triggered the calling job'),
     string(name: 'TRIGGER_REPO', defaultValue: '', description: 'The URI of the commit that triggered the calling job')
    ]),
-   [$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10']]
+   [$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10']],
+   [disableConcurrentBuilds()]
 ])
 node {
     //lock(resource: "pipeline_${env.NODE_NAME}_${env.JOB_NAME}", inversePrecedence: false) {


### PR DESCRIPTION
In our current production line, for each new commit pushed to a branch, a new Jenkins build is executed. This is problematic because CobiGen is blocking all the executors of our production line.

Adding property `disableConcurrentBuilds()`, only when the last commit build finishes, the next one will be triggered. 

For instance, I push to `master` commit A, Jenkins triggers a new build. Then I push 3 new commits B, C and D again to `master`. When Jenkins build A finishes, a new build with commits B, C and D will be triggered.

In my opinion, this makes more sense as I only want to know if the most up to date code passes the tests. Also it is worth to mention that it does not affect other branches builds. If I push to `dev_javaplugin` a new build will be triggered.

This has been requested by @dario-rodriguez 

@devonfw/cobigen
