### PR TITLE
Bug fix on core

### DIFF
--- a/cobigen/cobigen-core-parent/cobigen-core-api/src/main/java/com/devonfw/cobigen/api/constants/TemplatesJarConstants.java
+++ b/cobigen/cobigen-core-parent/cobigen-core-api/src/main/java/com/devonfw/cobigen/api/constants/TemplatesJarConstants.java
@@ -13,25 +13,25 @@ public class TemplatesJarConstants {
      * Jar regular expression name to be used in a file name filter, so that we can check whether the
      * templates are already downloaded. Checks "templates-anystring-anydigitbetweendots.jar"
      */
-    public static final String JAR_FILE_REGEX_NAME = "templates-([^-]+)-(\\d+\\.?)+.jar";
+    public static final String JAR_FILE_REGEX_NAME = "templates-([^-]+)-(\\d+\\.?)+.jar$";
 
     /**
      * Source jar regular expression name to be used in a file name filter, so that we can check whether the
      * templates are already downloaded. Checks "templates-anystring-anydigitbetweendots-sources.jar"
      */
-    public static final String SOURCES_FILE_REGEX_NAME = "templates-([^-]+)-(\\d+\\.?)+-sources.jar";
+    public static final String SOURCES_FILE_REGEX_NAME = "templates-([^-]+)-(\\d+\\.?)+-sources.jar$";
 
     /**
      * Jar regular expression used to check the version of the jar in oder to find out whether we should
      * update. Checks "templates-anystring-capturedigitsbetweendots.jar"
      */
-    public static final String JAR_VERSION_REGEX_CHECK = "templates-([^-]+)-(\\d+|\\d+(\\.\\d+)*)?\\.jar";
+    public static final String JAR_VERSION_REGEX_CHECK = "templates-([^-]+)-(\\d+|\\d+(\\.\\d+)*)?\\.jar$";
 
     /**
      * Sources jar regular expression used to check the version of the sources jar in oder to find out whether
      * we should update. Checks "templates-anystring-capturedigitsbetweendots-sources.jar"
      */
-    public static final String SOURCES_VERSION_REGEX_CHECK = "templates-([^-]+)-(\\d+|\\d+(\\.\\d+)*)?\\-sources.jar";
+    public static final String SOURCES_VERSION_REGEX_CHECK = "templates-([^-]+)-(\\d+|\\d+(\\.\\d+)*)?\\-sources.jar$";
 
     /**
      * GroupId of the latest devon4j templates jar on Maven Central

--- a/cobigen/cobigen-core-parent/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/externalprocess/ExternalProcessTest.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/externalprocess/ExternalProcessTest.java
@@ -17,10 +17,10 @@ public class ExternalProcessTest {
      */
     @Test
     public void startExternalProcess() {
-        ExternalProcessHandler request = ExternalProcessHandler
-            .getExternalProcessHandler(ExternalProcessConstants.HOST_NAME, ExternalProcessConstants.PORT);
+        ExternalProcessHandler request = ExternalProcessHandler.getExternalProcessHandler("/DummyExe",
+            ExternalProcessConstants.HOST_NAME, ExternalProcessConstants.PORT);
 
-        assertEquals(true, request.startServer("/DummyExe"));
+        assertEquals(true, request.startServer());
         assertEquals(true, request.terminateProcessConnection());
     }
 }


### PR DESCRIPTION
We found an issue on dev_core: the problem was when starting the external process, it threw a NPE because in my last PR I added some parameters on the URL that were null. Our tsplugin tests didn't show that error because they initialize the server prior to the tests. Now that is also fixed and I will create another PR.

@devonfw/cobigen
