### PR TITLE
Roll back without ts

### DIFF
--- a/cobigen-templates/templates-devon4j/src/main/templates/context.xml
+++ b/cobigen-templates/templates-devon4j/src/main/templates/context.xml
@@ -21,6 +21,7 @@
       <variableAssignment type="regex" key="entityName" value="5"/>
     </matcher>
   </trigger>
+  <!-- 
   <trigger id="crud_typescript_angular_client_app" type="typescript" templateFolder="crud_typescript_angular_client_app">
     <matcher type="fqn" value="([^\.]+).entity">
       <variableAssignment type="regex" key="entityName" value="1"/>
@@ -28,6 +29,7 @@
       <variableAssignment type="constant" key="domain" value="demo"/>
     </matcher>
   </trigger>
+   -->
   <trigger id="testdata_builder" type="java" templateFolder="testdata_builder">
     <containerMatcher type="package" value="((.+\.)?([^\.]+))\.([^\.]+)\.dataaccess\.api"
       retrieveObjectsRecursively="false"/>


### PR DESCRIPTION
The last templates released made use of the ts input reader. Unfortunately, this is not compatible with the current IDE. We need some kind of versioning here.

@devonfw/cobigen
