### PR TITLE
#716 Fixing prolog error

### DIFF
--- a/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/generator/InputInterpreterImpl.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/generator/InputInterpreterImpl.java
@@ -61,6 +61,19 @@ public class InputInterpreterImpl implements InputInterpreter {
     @Override
     public Object read(Path path, Charset inputCharset, Object... additionalArguments) throws InputReaderException {
         Set<String> keySet = PluginRegistry.getTriggerInterpreterKeySet();
+        // We first try to find an input reader that is most likely readable
+        for (String s : keySet) {
+            try {
+                if (isMostLikelyReadable(s, path)) {
+                    return getInputReader(s).read(path, inputCharset, additionalArguments);
+                }
+            } catch (InputReaderException e) {
+                // nothing to do.
+            }
+        }
+
+        // No input reader is most likely readable, then we try with every of them until we find the correct
+        // one
         for (String s : keySet) {
             try {
                 return getInputReader(s).read(path, inputCharset, additionalArguments);


### PR DESCRIPTION
Adresses/Fixes #716.

The `isMostLikelyReadable()` code that was implemented in order to fix issue #716, was not correctly used. In the CLI it was still showing `Error content 1:1 in prolog`. This fixes that issue by adding this logic on the core.

@devonfw/cobigen
