### PR TITLE
Making core JDK11 compatible

### DIFF
--- a/cobigen/cobigen-core-parent/cobigen-core/pom.xml
+++ b/cobigen/cobigen-core-parent/cobigen-core/pom.xml
@@ -70,6 +70,27 @@
       <version>2.2.1.GA</version>
     </dependency>
     
+    <!-- Needed for JDK 9  -->
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <version>2.3.0</version>
+    </dependency>    
+    
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>2.3.2</version>
+    </dependency>
+
+    <!-- END JDK 9 -->
+    
     <dependency>
       <groupId>net.sf.dozer</groupId>
       <artifactId>dozer</artifactId>
@@ -179,7 +200,7 @@
       <plugin>
         <groupId>org.jvnet.jaxb2.maven2</groupId>
         <artifactId>maven-jaxb2-plugin</artifactId>
-        <version>0.12.3</version>
+        <version>0.14.0</version>
         <executions>
           <execution>
             <id>generate-v1.0-configuration</id>

--- a/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/healthcheck/HealthCheckImpl.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/healthcheck/HealthCheckImpl.java
@@ -1,8 +1,6 @@
 package com.devonfw.cobigen.impl.healthcheck;
 
 import java.io.File;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -56,28 +54,31 @@ public class HealthCheckImpl implements HealthCheck {
 
         TemplateConfigurationUpgrader templateConfigurationUpgrader = new TemplateConfigurationUpgrader();
         try {
-            try {
-                templateConfigurationUpgrader.upgradeConfigurationToLatestVersion(templatesConfigurationFolder,
-                    backupPolicy);
-                LOG.info("Upgrade finished successfully.");
-            } catch (BackupFailedException e) {
-                healthCheckReport.addError(e);
-                if (healthCheckReport.getErrors().contains(BackupFailedException.class)) {
-                    templateConfigurationUpgrader.upgradeConfigurationToLatestVersion(templatesConfigurationFolder,
-                        BackupPolicy.NO_BACKUP);
-                    LOG.info("Upgrade finished successfully but without backup.");
-                } else {
-                    healthCheckReport.addError(new CobiGenRuntimeException("Upgrade aborted"));
-                    LOG.info("Upgrade aborted.");
-                }
-            }
-        } catch (RuntimeException e) {
+            templateConfigurationUpgrader.upgradeConfigurationToLatestVersion(templatesConfigurationFolder,
+                backupPolicy);
+            LOG.info("Upgrade finished successfully.");
+        } catch (BackupFailedException e) {
             healthCheckReport.addError(e);
-            healthCheckReport
-                .addErrorMessages("An unexpected error occurred while upgrading the templates configuration");
-            LOG.error("An unexpected error occurred while upgrading the templates configuration.", e);
+            if (containsAnyExceptionOfClass(BackupFailedException.class)) {
+                templateConfigurationUpgrader.upgradeConfigurationToLatestVersion(templatesConfigurationFolder,
+                    BackupPolicy.NO_BACKUP);
+                LOG.info("Upgrade finished successfully but without backup.");
+            } else {
+                healthCheckReport.addError(new CobiGenRuntimeException("Upgrade aborted"));
+                LOG.info("Upgrade aborted.");
+            }
         }
         return healthCheckReport;
+    }
+
+    /**
+     * @param typeToBeFound
+     *            the type to find
+     * @return true if any exception in the list of errors of the health check is equal to or subtype of the
+     *         parameter
+     */
+    private boolean containsAnyExceptionOfClass(Class<? extends RuntimeException> typeToBeFound) {
+        return healthCheckReport.getErrors().stream().anyMatch(e -> typeToBeFound.isAssignableFrom(e.getClass()));
     }
 
     @Override
@@ -116,82 +117,75 @@ public class HealthCheckImpl implements HealthCheck {
     }
 
     @Override
-	public HealthCheckReport perform(Path configurationPath) {
-		try {
-			// 1. Get configuration resources
-			// determine expected template configurations to be defined
-			ContextConfiguration contextConfiguration = new ContextConfiguration(configurationPath);
-			List<String> expectedTemplatesConfigurations = Lists.newArrayList();
-			Set<String> hasConfiguration = Sets.newHashSet();
-			Set<String> isAccessible = Sets.newHashSet();
-			Map<String, Path> upgradeableConfigurations = Maps.newHashMap();
-			Set<String> upToDateConfigurations = Sets.newHashSet();
-			Path pathForCobigenTemplates = null;
-			for (Trigger t : contextConfiguration.getTriggers()) {
-				expectedTemplatesConfigurations.add(t.getTemplateFolder());
-			}
-			// 2. Determine current state
-			TemplateConfigurationUpgrader templateConfigurationUpgrader = new TemplateConfigurationUpgrader();
-			pathForCobigenTemplates = Paths.get(configurationPath + File.separator + "src" + File.separator + "main"
-					+ File.separator + "templates");
+    public HealthCheckReport perform(Path configurationPath) {
+        // 1. Get configuration resources
+        // determine expected template configurations to be defined
+        ContextConfiguration contextConfiguration = new ContextConfiguration(configurationPath);
+        List<String> expectedTemplatesConfigurations = Lists.newArrayList();
+        Set<String> hasConfiguration = Sets.newHashSet();
+        Set<String> isAccessible = Sets.newHashSet();
+        Map<String, Path> upgradeableConfigurations = Maps.newHashMap();
+        Set<String> upToDateConfigurations = Sets.newHashSet();
+        Path pathForCobigenTemplates = null;
+        for (Trigger t : contextConfiguration.getTriggers()) {
+            expectedTemplatesConfigurations.add(t.getTemplateFolder());
+        }
+        // 2. Determine current state
+        TemplateConfigurationUpgrader templateConfigurationUpgrader = new TemplateConfigurationUpgrader();
+        pathForCobigenTemplates = Paths
+            .get(configurationPath + File.separator + "src" + File.separator + "main" + File.separator + "templates");
 
-			for (String expectedTemplateFolder : expectedTemplatesConfigurations) {
-				if (pathForCobigenTemplates.toFile().exists()) {
-					String configPath = (configurationPath + File.separator + "src" + File.separator + "main"
-							+ File.separator + "templates").toString();
-					hasConfiguration.add(configPath);
-					isAccessible.add(configPath);
-					Path expectedTemplateFolderForResolvedVer = (Paths.get(pathForCobigenTemplates + File.separator
-							+ expectedTemplateFolder.replace("/", File.separator)));
-					TemplatesConfigurationVersion resolvedVersion = templateConfigurationUpgrader
-							.resolveLatestCompatibleSchemaVersion(expectedTemplateFolderForResolvedVer);
-					if (resolvedVersion != null) {
-						if (resolvedVersion != TemplatesConfigurationVersion.getLatest()) {
-							upgradeableConfigurations.put(expectedTemplateFolder, pathForCobigenTemplates);
-						} else {
-							upToDateConfigurations.add(expectedTemplateFolder);
-						}
-					}
+        for (String expectedTemplateFolder : expectedTemplatesConfigurations) {
+            if (pathForCobigenTemplates.toFile().exists()) {
+                String configPath = (configurationPath + File.separator + "src" + File.separator + "main"
+                    + File.separator + "templates").toString();
+                hasConfiguration.add(configPath);
+                isAccessible.add(configPath);
+                Path expectedTemplateFolderForResolvedVer = (Paths.get(
+                    pathForCobigenTemplates + File.separator + expectedTemplateFolder.replace("/", File.separator)));
+                TemplatesConfigurationVersion resolvedVersion = templateConfigurationUpgrader
+                    .resolveLatestCompatibleSchemaVersion(expectedTemplateFolderForResolvedVer);
+                if (resolvedVersion != null) {
+                    if (resolvedVersion != TemplatesConfigurationVersion.getLatest()) {
+                        upgradeableConfigurations.put(expectedTemplateFolder, pathForCobigenTemplates);
+                    } else {
+                        upToDateConfigurations.add(expectedTemplateFolder);
+                    }
+                }
 
-				} else {
+            } else {
 
-					Path templateFolder = configurationPath.resolve(expectedTemplateFolder);
-					Path templatesConfigurationPath = templateFolder
-							.resolve(ConfigurationConstants.TEMPLATES_CONFIG_FILENAME);
-					File templatesConfigurationFile = templatesConfigurationPath.toFile();
-					if (templatesConfigurationFile.exists()) {
-						hasConfiguration.add(expectedTemplateFolder);
-						if (templatesConfigurationFile.canWrite()) {
-							isAccessible.add(expectedTemplateFolder);
+                Path templateFolder = configurationPath.resolve(expectedTemplateFolder);
+                Path templatesConfigurationPath =
+                    templateFolder.resolve(ConfigurationConstants.TEMPLATES_CONFIG_FILENAME);
+                File templatesConfigurationFile = templatesConfigurationPath.toFile();
+                if (templatesConfigurationFile.exists()) {
+                    hasConfiguration.add(expectedTemplateFolder);
+                    if (templatesConfigurationFile.canWrite()) {
+                        isAccessible.add(expectedTemplateFolder);
 
-							TemplatesConfigurationVersion resolvedVersion = templateConfigurationUpgrader
-									.resolveLatestCompatibleSchemaVersion(templateFolder);
-							if (resolvedVersion != null) {
-								if (resolvedVersion != TemplatesConfigurationVersion.getLatest()) {
-									upgradeableConfigurations.put(expectedTemplateFolder, templateFolder);
-								} else {
-									upToDateConfigurations.add(expectedTemplateFolder);
-								}
-							}
-						}
-					}
+                        TemplatesConfigurationVersion resolvedVersion =
+                            templateConfigurationUpgrader.resolveLatestCompatibleSchemaVersion(templateFolder);
+                        if (resolvedVersion != null) {
+                            if (resolvedVersion != TemplatesConfigurationVersion.getLatest()) {
+                                upgradeableConfigurations.put(expectedTemplateFolder, templateFolder);
+                            } else {
+                                upToDateConfigurations.add(expectedTemplateFolder);
+                            }
+                        }
+                    }
+                }
 
-				}
-			}
+            }
+        }
 
-			healthCheckReport.setExpectedTemplatesConfigurations(expectedTemplatesConfigurations);
-			healthCheckReport.setHasConfiguration(hasConfiguration);
-			healthCheckReport.setIsAccessible(isAccessible);
-			healthCheckReport.setUpgradeableConfigurations(upgradeableConfigurations);
-			healthCheckReport.setUpToDateConfigurations(upToDateConfigurations);
+        healthCheckReport.setExpectedTemplatesConfigurations(expectedTemplatesConfigurations);
+        healthCheckReport.setHasConfiguration(hasConfiguration);
+        healthCheckReport.setIsAccessible(isAccessible);
+        healthCheckReport.setUpgradeableConfigurations(upgradeableConfigurations);
+        healthCheckReport.setUpToDateConfigurations(upToDateConfigurations);
 
-		} catch (RuntimeException e) {
-			e.printStackTrace();
-			healthCheckReport.addError(e);
-			healthCheckReport.addErrorMessages("An unexpected exception occurred.");
-			LOG.error("An unexpected exception occurred.", e);
-		}
-		return healthCheckReport;
-	}
+        return healthCheckReport;
+    }
 
 }

--- a/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/util/TemplatesJarUtil.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/util/TemplatesJarUtil.java
@@ -82,7 +82,7 @@ public class TemplatesJarUtil {
 
         String mavenUrl = "https://repository.sonatype.org/service/local/artifact/maven/"
             + "redirect?r=central-proxy&g=" + groupId + "&a=" + artifactId + "&v=" + version;
-        ;
+
         if (isDownloadSource) {
             mavenUrl = mavenUrl + "&c=sources";
         }

--- a/cobigen/cobigen-core-parent/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/healthcheck/HealthCheckTest.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/healthcheck/HealthCheckTest.java
@@ -1,7 +1,6 @@
 package com.devonfw.cobigen.unittest.healthcheck;
 
 import static com.devonfw.cobigen.test.assertj.CobiGenAsserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -160,11 +159,11 @@ public class HealthCheckTest {
     }
 
     /**
-     * Testing Error Message for an Invalid Templates Configuration.
+     * Testing an Invalid Templates Configuration.
      * @throws IOException
      *             not thrown
      */
-    @Test
+    @Test(expected = InvalidConfigurationException.class)
     public void testFailingTemplatesConfigUpgrade() throws IOException {
 
         HealthCheckImpl healthcheck = new HealthCheckImpl();
@@ -173,10 +172,7 @@ public class HealthCheckTest {
         Path executionFolder = tempFolder.getRoot().toPath().resolve("testFailingUpgradeTemplatesConfig");
         FileUtils.copyDirectory(configurationFolder.toFile(), executionFolder.toFile());
         // act
-        HealthCheckReport report = healthcheck.upgradeTemplatesConfiguration(executionFolder, backuppolicy);
-        System.out.print(report.getErrors());
-        assertThat(report.getErrors().toString())
-            .contains("Templates Configuration does not match any current or legacy schema definitions.");
+        healthcheck.upgradeTemplatesConfiguration(executionFolder, backuppolicy);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -203,8 +203,10 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.9.1</version>
+          <version>3.1.1</version>
           <configuration>
+          <!-- needed to fix javadoc on java 11+-->
+            <source>8</source>
             <quiet>true</quiet>
           </configuration>
         </plugin>


### PR DESCRIPTION
Implementing needed changes in order to make the CobIGen core JDK 11 compatible. Thanks to the help of @maybeec we have been able to have this fixed.

I also had to add some changes on the master pom as the JavaDoc generation was not compatible with JDK 11.

@devonfw/cobigen
