### PR TITLE
Making Eclipse JDK 11 compatible

### DIFF
--- a/cobigen-eclipse/cobigen-eclipse/.classpath
+++ b/cobigen-eclipse/cobigen-eclipse/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="lib/core-5.4.0-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/core-api-5.4.0-SNAPSHOT.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/core-5.4.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/core-api-5.4.0.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/"/>

--- a/cobigen-eclipse/cobigen-eclipse/.classpath
+++ b/cobigen-eclipse/cobigen-eclipse/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="lib/core-5.3.4.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/core-api-5.3.4.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/core-5.4.0-SNAPSHOT.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/core-api-5.4.0-SNAPSHOT.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/"/>
@@ -22,5 +22,8 @@
 	<classpathentry exported="true" kind="lib" path="lib/mmm-util-core-7.4.0.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/slf4j-api-1.7.21.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/javaplugin-model-2.0.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/jaxb-api-2.3.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/jaxb-runtime-2.3.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/jaxb-core-2.3.0.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/cobigen-eclipse/cobigen-eclipse/META-INF/MANIFEST.MF
+++ b/cobigen-eclipse/cobigen-eclipse/META-INF/MANIFEST.MF
@@ -37,6 +37,9 @@ Bundle-ClassPath: .,
  lib/mmm-util-core-7.4.0.jar,
  lib/slf4j-api-1.7.21.jar,
  lib/javaplugin-model-2.0.0.jar,
- lib/core-5.3.4.jar,
- lib/core-api-5.3.4.jar
+ lib/jaxb-api-2.3.1.jar,
+ lib/jaxb-runtime-2.3.2.jar,
+ lib/jaxb-core-2.3.0.jar,
+ lib/core-5.4.0-SNAPSHOT.jar,
+ lib/core-api-5.4.0-SNAPSHOT.jar
 Export-Package: com.devonfw.cobigen.eclipse.common.constants.external

--- a/cobigen-eclipse/cobigen-eclipse/META-INF/MANIFEST.MF
+++ b/cobigen-eclipse/cobigen-eclipse/META-INF/MANIFEST.MF
@@ -40,6 +40,6 @@ Bundle-ClassPath: .,
  lib/jaxb-api-2.3.1.jar,
  lib/jaxb-runtime-2.3.2.jar,
  lib/jaxb-core-2.3.0.jar,
- lib/core-5.4.0-SNAPSHOT.jar,
- lib/core-api-5.4.0-SNAPSHOT.jar
+ lib/core-5.4.0.jar,
+ lib/core-api-5.4.0.jar
 Export-Package: com.devonfw.cobigen.eclipse.common.constants.external

--- a/cobigen-eclipse/cobigen-eclipse/build.properties
+++ b/cobigen-eclipse/cobigen-eclipse/build.properties
@@ -20,5 +20,8 @@ bin.includes = .,\
                lib/mmm-util-core-7.4.0.jar,\
                lib/slf4j-api-1.7.21.jar,\
                lib/javaplugin-model-2.0.0.jar,\
-               lib/core-5.3.4.jar,\
-               lib/core-api-5.3.4.jar
+               lib/jaxb-api-2.3.1.jar,\
+               lib/jaxb-runtime-2.3.2.jar,\
+               lib/jaxb-core-2.3.0.jar,\
+               lib/core-5.4.0-SNAPSHOT.jar,\
+               lib/core-api-5.4.0-SNAPSHOT.jar

--- a/cobigen-eclipse/cobigen-eclipse/build.properties
+++ b/cobigen-eclipse/cobigen-eclipse/build.properties
@@ -23,5 +23,5 @@ bin.includes = .,\
                lib/jaxb-api-2.3.1.jar,\
                lib/jaxb-runtime-2.3.2.jar,\
                lib/jaxb-core-2.3.0.jar,\
-               lib/core-5.4.0-SNAPSHOT.jar,\
-               lib/core-api-5.4.0-SNAPSHOT.jar
+               lib/core-5.4.0.jar,\
+               lib/core-api-5.4.0.jar

--- a/cobigen-eclipse/cobigen-eclipse/pom.xml
+++ b/cobigen-eclipse/cobigen-eclipse/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.devonfw.cobigen</groupId>
       <artifactId>core</artifactId>
-      <version>5.3.4</version>
+      <version>5.4.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.devonfw.cobigen</groupId>

--- a/cobigen-eclipse/cobigen-eclipse/pom.xml
+++ b/cobigen-eclipse/cobigen-eclipse/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.devonfw.cobigen</groupId>
       <artifactId>core</artifactId>
-      <version>5.4.0-SNAPSHOT</version>
+      <version>5.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.devonfw.cobigen</groupId>


### PR DESCRIPTION
Making Eclipse plug-in JDK 11 compatible. In order to do that, we had to add some dependencies to the Eclipse lib

## Note:

The CobiGen core version should be changed when released!

@devonfw/cobigen
