### PR TITLE
Eclipse threw plugin not available exception

### DIFF
--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/generator/generic/FileInputConverter.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/generator/generic/FileInputConverter.java
@@ -52,24 +52,48 @@ public class FileInputConverter {
                     charset = Charset.forName("UTF-8");
                 }
                 Path inputFilePath = Paths.get(inputFile.getLocationURI());
-                String readerType;
+                String readerType = "";
 
-                if (cobigen.isMostLikelyReadable("xml", inputFilePath)) {
-                    readerType = "xml";
-                    readAndAddInput(cobigen, convertedInputs, inputType, readerType, inputFilePath, charset);
-                    continue;
+                try {
+                    if (cobigen.isMostLikelyReadable("xml", inputFilePath)) {
+                        readerType = "xml";
+                        readAndAddInput(cobigen, convertedInputs, inputType, readerType, inputFilePath, charset);
+                        continue;
+                    }
+                } catch (InputReaderException e) {
+                    LOG.trace("Could not read file {} with input reader of type '{}'", inputFile.getLocationURI(),
+                        readerType, e);
+                    // try next
+                } catch (PluginNotAvailableException e) {
+                    LOG.trace(e.getMessage(), e);
                 }
 
-                else if (cobigen.isMostLikelyReadable("typescript", inputFilePath)) {
-                    readerType = "typescript";
-                    readAndAddInput(cobigen, convertedInputs, inputType, readerType, inputFilePath, charset);
-                    continue;
+                try {
+                    if (cobigen.isMostLikelyReadable("typescript", inputFilePath)) {
+                        readerType = "typescript";
+                        readAndAddInput(cobigen, convertedInputs, inputType, readerType, inputFilePath, charset);
+                        continue;
+                    }
+                } catch (InputReaderException e) {
+                    LOG.trace("Could not read file {} with input reader of type '{}'", inputFile.getLocationURI(),
+                        readerType, e);
+                    // try next
+                } catch (PluginNotAvailableException e) {
+                    LOG.trace(e.getMessage(), e);
                 }
 
-                else if (cobigen.isMostLikelyReadable("openapi", inputFilePath)) {
-                    readerType = "openapi";
-                    readAndAddInput(cobigen, convertedInputs, inputType, readerType, inputFilePath, charset);
-                    continue;
+                try {
+                    if (cobigen.isMostLikelyReadable("openapi", inputFilePath)) {
+                        readerType = "openapi";
+                        readAndAddInput(cobigen, convertedInputs, inputType, readerType, inputFilePath, charset);
+                        continue;
+                    }
+                } catch (InputReaderException e) {
+                    LOG.trace("Could not read file {} with input reader of type '{}'", inputFile.getLocationURI(),
+                        readerType, e);
+                    // try next
+                } catch (PluginNotAvailableException e) {
+                    LOG.trace(e.getMessage(), e);
                 }
 
                 readerType = "xml";


### PR DESCRIPTION
Eclipse plug-in threw plug-in not available exception when using `isMostLikelyReadable(...)`. This was critical because if a plug-in is missing, we want CobiGen to keep working.

@devonfw/cobigen
