### PR TITLE
Remove deprecated M2_HOME environment variable

### DIFF
--- a/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/utils/CobiGenUtils.java
+++ b/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/utils/CobiGenUtils.java
@@ -275,8 +275,12 @@ public class CobiGenUtils {
 
             Invoker invoker = new DefaultInvoker();
             InvocationResult result = null;
+
+            // Progress bar starts
             Thread t1 = new Thread(new ProgressBar());
             t1.start();
+
+            invoker.setMavenHome(new File(System.getenv("MAVEN_HOME")));
             result = invoker.execute(request);
             if (t1 != null) {
                 t1.interrupt();

--- a/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/utils/CobiGenUtils.java
+++ b/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/utils/CobiGenUtils.java
@@ -280,7 +280,13 @@ public class CobiGenUtils {
             Thread t1 = new Thread(new ProgressBar());
             t1.start();
 
-            invoker.setMavenHome(new File(System.getenv("MAVEN_HOME")));
+            try {
+                invoker.setMavenHome(new File(System.getenv("MAVEN_HOME")));
+            } catch (NullPointerException e) {
+                logger.error(
+                    "MAVEN_HOME environment variable has not been set on your machine. CobiGen CLI needs Maven correctly configured.",
+                    e);
+            }
             result = invoker.execute(request);
             if (t1 != null) {
                 t1.interrupt();


### PR DESCRIPTION
Due to devon-ide requirement on PR [#273](https://github.com/devonfw/ide/pull/273), where they requested not to use `M2_HOME` variable as it is deprecated, I create this PR to fix that issue.

I programmatically set `MAVEN_HOME` as the default variable.

@devonfw/cobigen
