### PR TITLE
#921: fixed artifactId of cobigen-parent POM

### DIFF
--- a/cobigen/cobigen-core-parent/pom.xml
+++ b/cobigen/cobigen-core-parent/pom.xml
@@ -7,7 +7,7 @@
 
   <parent>
     <groupId>com.devonfw.cobigen</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>cobigen-parent</artifactId>
     <version>dev-SNAPSHOT</version>
   </parent>
 


### PR DESCRIPTION
Adresses/Fixes #921.

Implements

* change artifactId from `parent` to `cobigen-parent` as child modules are using/expecting this 

@devonfw/cobigen
